### PR TITLE
Restore engine-specific packaging for Fab

### DIFF
--- a/UET/uet/Commands/Internal/UpdateUPlugin/UpdateUPluginCommand.cs
+++ b/UET/uet/Commands/Internal/UpdateUPlugin/UpdateUPluginCommand.cs
@@ -74,18 +74,19 @@
                     return 1;
                 }
 
-                if (packageType != BuildConfigPluginPackageType.Fab)
+
+                //if (packageType != BuildConfigPluginPackageType.Fab)
                 {
                     node["EngineVersion"] = engineVersion;
                 }
-                else
+                /*else
                 {
                     var obj = node.AsObject();
                     if (obj.ContainsKey("EngineVersion"))
                     {
                         obj.Remove("EngineVersion");
                     }
-                }
+                }*/
                 node["VersionName"] = versionName;
                 node["Version"] = ulong.Parse(versionNumber, CultureInfo.InvariantCulture);
                 node["Installed"] = true;

--- a/UET/uet/Services/DefaultPluginVersioning.cs
+++ b/UET/uet/Services/DefaultPluginVersioning.cs
@@ -72,14 +72,14 @@
                 var versionNumber = pluginVersioningType switch
                 {
                     BuildConfigPluginPackageType.Marketplace => $"{unixTimestamp}{engineInfo.MinorVersion}",
-                    BuildConfigPluginPackageType.Fab => $"{unixTimestamp}",
+                    BuildConfigPluginPackageType.Fab => $"{unixTimestamp}{engineInfo.MinorVersion}",
                     BuildConfigPluginPackageType.Generic => $"{unixTimestamp}{engineInfo.MinorVersion}",
                     _ => throw new NotSupportedException("The value of 'BuildConfigPluginPackageType' is not supported in ComputeVersionNameAndNumberAsync."),
                 };
                 var versionName = pluginVersioningType switch
                 {
                     BuildConfigPluginPackageType.Marketplace => $"{versionDateTime}-{engineInfo.MajorVersion}.{engineInfo.MinorVersion}-{ciCommitShortSha[..8]}",
-                    BuildConfigPluginPackageType.Fab => $"{versionDateTime}-{ciCommitShortSha[..8]}",
+                    BuildConfigPluginPackageType.Fab => $"{versionDateTime}-{engineInfo.MajorVersion}.{engineInfo.MinorVersion}-{ciCommitShortSha[..8]}",
                     BuildConfigPluginPackageType.Generic => $"{versionDateTime}-{engineInfo.MajorVersion}.{engineInfo.MinorVersion}-{ciCommitShortSha[..8]}",
                     _ => throw new NotSupportedException("The value of 'BuildConfigPluginPackageType' is not supported in ComputeVersionNameAndNumberAsync."),
                 };


### PR DESCRIPTION
Turns out Fab doesn't actually support a single upload for multiple engine versions for code plugins, and we still need to submit (mostly identical) packages to them for each engine version.