### PR TITLE
Try to fix permissions issue on uploading test results

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -126,4 +126,13 @@ runs:
         if-no-files-found: error
         path: |
           **/*.nupkg
+
+    - name: Upload Test Results
+      if: ${{ inputs.UET_ARTIFACT_NAME == 'test-results' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        if-no-files-found: error
+        path: |
+          TestResults/*.test-result.trx
           

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -1,0 +1,30 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["Unreal Engine Tool"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      checks: write
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: test-results
+        path: TestResults/
+        run-id: ${{ github.event.workflow_run.id }}
+    - name: Report Test Results
+      uses: dorny/test-reporter@v1
+      with:
+        name: Windows Test Results
+        path: TestResults/*.test-result.trx
+        reporter: dotnet-trx

--- a/.github/workflows/uet.yml
+++ b/.github/workflows/uet.yml
@@ -524,13 +524,11 @@ jobs:
             Write-Host "============ PASSED:   $($Item.Name) ============"
           }
         }
-    - name: Report Test Results
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-artifact
       with:
-        name: Windows Test Results
-        path: TestResults/*.test-result.trx
-        reporter: dotnet-trx
+        UET_ARTIFACT_NAME: test-results
+        UET_FRAMEWORK_TARGET: ${{ env.UET_FRAMEWORK_TARGET }}
     - name: Upload Packages
       uses: ./.github/actions/upload-artifact
       with:


### PR DESCRIPTION
This moves the test reporting step to a separate workflow that should, if my understanding of GitHub Actions is correct, work for pull requests submitted by external contributors.