### PR TITLE
Add unsupported --legacy flag for targeting Unreal Engine 4

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/BuildGraphPatchSet.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/BuildGraphPatchSet.cs
@@ -7,8 +7,11 @@
         [JsonPropertyName("File"), JsonRequired]
         public string File { get; set; } = string.Empty;
 
+        [JsonPropertyName("Output4")]
+        public string? Output4 { get; set; } = null;
+
         [JsonPropertyName("Output5"), JsonRequired]
-        public string Output { get; set; } = string.Empty;
+        public string Output5 { get; set; } = string.Empty;
 
         [JsonPropertyName("Patches"), JsonRequired]
         public BuildGraphPatchSetPatch[] Patches { get; set; } = Array.Empty<BuildGraphPatchSetPatch>();

--- a/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
@@ -339,6 +339,19 @@
             return ($"__SHARED_STORAGE_PATH__/{nodeFilename}", $"__SHARED_STORAGE_PATH__/{macroFilename}");
         }
 
+        private static bool IsUnrealEngine4(string enginePath)
+        {
+            var buildVersionFilePath = Path.Combine(enginePath, "Engine", "Build", "Build.version");
+            if (File.Exists(buildVersionFilePath))
+            {
+                if (File.ReadAllText(buildVersionFilePath).Contains("UE4", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public async Task<BuildSpecification> BuildConfigPluginToBuildSpecAsync(
             BuildEngineSpecification engineSpec,
             BuildGraphEnvironment buildGraphEnvironment,
@@ -353,7 +366,8 @@
             bool localExecutor,
             bool isPluginRooted,
             string? commandlinePluginVersionName,
-            long? commandlinePluginVersionNumber)
+            long? commandlinePluginVersionNumber,
+            bool legacy)
         {
             // Determine build matrix.
             var editorTargetPlatforms = FilterIncompatiblePlatforms((distribution.Build.Editor?.Platforms ?? new[] { BuildConfigPluginBuildEditorPlatform.Win64 }).Select(x =>
@@ -520,7 +534,7 @@
                     { "ScriptMacroIncludes", scriptMacroIncludes },
 
                     // General options
-                    { "IsUnrealEngine5", "true" },
+                    { "IsUnrealEngine5", legacy ? "false" : "true" },
 
                     // Clean options
                     { $"CleanDirectories", string.Join(";", cleanDirectories) },
@@ -537,7 +551,7 @@
                     { $"MacPlatforms", $"IOS;Mac" },
                     { $"StrictIncludes", strictIncludes || strictIncludesAtPluginLevel ? "true" : "false" },
                     { $"Allow2019", "false" },
-                    { $"EnginePrefix", "Unreal" },
+                    { $"EnginePrefix", legacy ? "UE4" : "Unreal" },
 
                     // Package options
                     { $"ExecutePackage", executePackage ? "true" : "false" },

--- a/UET/uet/Commands/Build/IBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/IBuildSpecificationGenerator.cs
@@ -35,7 +35,8 @@
             bool localExecutor,
             bool isPluginRooted,
             string? commandlinePluginVersionName,
-            long? commandlinePluginVersionNumber);
+            long? commandlinePluginVersionNumber,
+            bool legacy);
 
         Task<BuildSpecification> BuildConfigEngineToBuildSpecAsync(
             BuildEngineSpecification engineSpec,

--- a/UET/uet/Commands/Test/TestCommand.cs
+++ b/UET/uet/Commands/Test/TestCommand.cs
@@ -285,7 +285,8 @@
                                 localExecutor: true,
                                 isPluginRooted: true,
                                 commandlinePluginVersionName: null,
-                                commandlinePluginVersionNumber: null).ConfigureAwait(false);
+                                commandlinePluginVersionNumber: null,
+                                false).ConfigureAwait(false);
                             break;
                         default:
                             throw new NotSupportedException();


### PR DESCRIPTION
Fab added support for Unreal Engine code plugins to submit updates for engine versions older than the last 3 versions, at least going back to 4.27.

This was my initial attempt to add 4.x support to UET via a `--legacy` flag, however in practice:

 - My build environment isn't set up for UE4 any more and UET can't auto-install dependencies for that engine version, and
 - Most of my own plugin code has dropped the relevant code guards necessary to support UE4 (even for plugins like OSB or RSI).

Since I can't actually test everything works end-to-end with this flag, I don't intend to merge it in at this time.