### PR TITLE
Implement custom deployment provider

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/BuildConfigProjectDeploymentCustom.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/BuildConfigProjectDeploymentCustom.cs
@@ -9,11 +9,6 @@
         /// The script receives the following parameters:
         ///   -EnginePath "C:\Path\To\UnrealEngine"
         ///   -StageDirectory "C:\Path\To\UProject\Saved\StagedBuilds"
-        ///   -PackageDirectory "C:\Path\To\UProject\Saved\StagedBuilds\LinuxServer"
-        ///   -PackageType "Game"
-        ///   -PackageTarget "ExampleOSS"
-        ///   -PackagePlatform "Win64"
-        ///   -PackageConfiguration "DebugGame"
         /// </summary>
         [JsonPropertyName("ScriptPath"), JsonRequired]
         public string ScriptPath { get; set; } = string.Empty;

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/CustomProjectDeploymentProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/CustomProjectDeploymentProvider.cs
@@ -1,6 +1,7 @@
 ﻿namespace Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Custom
 {
     using Redpoint.RuntimeJson;
+    using Redpoint.Uet.BuildGraph;
     using Redpoint.Uet.Configuration.Dynamic;
     using Redpoint.Uet.Configuration.Project;
     using System;
@@ -14,13 +15,51 @@
 
         public IRuntimeJson DynamicSettings { get; } = new DeploymentProviderRuntimeJson(DeploymentProviderSourceGenerationContext.WithStringEnum).BuildConfigProjectDeploymentCustom;
 
-        public Task WriteBuildGraphNodesAsync(
+        public async Task WriteBuildGraphNodesAsync(
             IBuildGraphEmitContext context,
             XmlWriter writer,
             BuildConfigProjectDistribution buildConfigDistribution,
             IEnumerable<BuildConfigDynamic<BuildConfigProjectDistribution, IDeploymentProvider>> elements)
         {
-            throw new NotImplementedException();
+            var castedSettings = elements
+                .Select(x => (name: x.Name, manual: x.Manual ?? false, settings: (BuildConfigProjectDeploymentCustom)x.DynamicSettings))
+                .ToList();
+
+            foreach (var deployment in castedSettings)
+            {
+                await writer.WriteAgentNodeAsync(
+                    new AgentNodeElementProperties
+                    {
+                        AgentStage = $"Deployment {deployment.name}",
+                        AgentType = deployment.manual ? "Win64_Manual" : "Win64",
+                        NodeName = $"Deployment {deployment.name}",
+                        Requires = $"$(GameStaged);$(ClientStaged);$(ServerStaged);$(DynamicPreDeploymentNodes)",
+                    },
+                    async writer =>
+                    {
+                        await writer.WriteSpawnAsync(
+                            new SpawnElementProperties
+                            {
+                                Exe = "powershell.exe",
+                                Arguments = new[]
+                                {
+                                    "-ExecutionPolicy",
+                                    "Bypass",
+                                    "-File",
+                                    $@"""$(RepositoryRoot)/{deployment.settings.ScriptPath}""",
+                                    "-EnginePath",
+                                    $@"""$(EnginePath)""",
+                                    "-StageDirectory",
+                                    $@"""$(StageDirectory)""",
+                                }
+                            }).ConfigureAwait(false);
+                    }).ConfigureAwait(false);
+                await writer.WriteDynamicNodeAppendAsync(
+                    new DynamicNodeAppendElementProperties
+                    {
+                        NodeName = $"Deployment {deployment.name}",
+                    }).ConfigureAwait(false);
+            }
         }
     }
 }


### PR DESCRIPTION
Hey June,

I looked into implementing the custom project deployment provider. 
I implemented it similar to the custom project test provider, which is to just grab all binaries and invoke the script once.

Do you think this implementation makes sense, or would you rather have something like the Steam provider where you invoke the script for a specific target?