### PR TITLE
Add support for predefining tests and using them in `uet test`

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Test/Plugin/Custom/CustomPluginTestProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Test/Plugin/Custom/CustomPluginTestProvider.cs
@@ -22,7 +22,6 @@
 
         public IRuntimeJson DynamicSettings { get; } = new TestProviderRuntimeJson(TestProviderSourceGenerationContext.WithStringEnum).BuildConfigPluginTestCustom;
 
-
         public async Task WriteBuildGraphNodesAsync(
             IBuildGraphEmitContext context,
             XmlWriter writer,

--- a/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
@@ -128,6 +128,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"Allow2019", $"false" },
                     { $"EnginePrefix", $"Unreal" },
                     { $"ExecutePackage", $"false" },
+                    { $"ExecuteZip", $"false" },
                     { $"VersionNumber", $"10000" },
                     { $"VersionName", $"2023.05.17" },
                     { $"PackageName", $"Packaged" },

--- a/UET/Redpoint.Uet.BuildPipeline.Tests/DynamicBuildGraphIncludeTests.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Tests/DynamicBuildGraphIncludeTests.cs
@@ -52,6 +52,7 @@
                 await writer.WriteBuildGraphNodeInclude(
                     memory,
                     false,
+                    new BuildConfigPlugin(),
                     new BuildConfigPluginDistribution
                     {
                         Name = "Test",

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
@@ -34,6 +34,7 @@
 
   <!-- Package options -->
   <Option Name="ExecutePackage" Restrict="true|false" DefaultValue="true" Description="If false, the default Create Package and Zip Plugin steps are not run" />
+  <Option Name="ExecuteZip" Restrict="true|false" DefaultValue="true" Description="If false, the Create Package step will not generate a .zip file" />
   <Option Name="VersionNumber" Restrict="[0-9]+" DefaultValue="10000" Description="The version number to embed in the packaged .uplugin file" />
   <Option Name="VersionName" Restrict="[^ ]+" DefaultValue="Unversioned" Description="The version name to embed in the packaged .uplugin file" />
   <Option Name="PackageFolder" Restrict="[^ ]+" DefaultValue="Packaged" Description="The folder to place the packaged plugin in" />
@@ -606,7 +607,9 @@ $(PackageExclude);
       OutputTag="#PackagedPlugin"
       If="'$(ExecutePackage)' == 'true'"
     />
-    <Agent Name="Zip Plugin (Create Final Package)" Type="Win64">
+    <Property Name="PackageTasks" Value="$(PackageTasks)#PackagedPlugin;" />
+
+    <Agent Name="Zip Plugin (Create Final Package)" Type="Win64" If="'$(ExecuteZip)' == 'true'">
       <Node Name="Zip Plugin" Requires="#PackagedPlugin" Produces="#PackagedZip">
         <Delete Files="$(ProjectRoot)/$(PluginName)-$(Distribution)-$(VersionName).zip" />
         <Zip
@@ -617,7 +620,7 @@ $(PackageExclude);
       />
       </Node>
     </Agent>
-    <Property Name="PackageTasks" Value="$(PackageTasks)#PackagedZip;#PackagedPlugin;" />
+    <Property Name="PackageTasks" Value="$(PackageTasks)#PackagedZip;" If="'$(ExecuteZip)' == 'true'" />
   </Do>
 
   <!-- 

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Dynamic/IDynamicBuildGraphIncludeWriter.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Dynamic/IDynamicBuildGraphIncludeWriter.cs
@@ -7,6 +7,7 @@
         Task WriteBuildGraphNodeInclude(
             Stream stream,
             bool filterHostToCurrentPlatformOnly,
+            object buildConfig,
             object buildConfigDistribution,
             bool executeTests,
             bool executeDeployment);
@@ -14,6 +15,7 @@
         Task WriteBuildGraphMacroInclude(
             Stream stream,
             bool filterHostToCurrentPlatformOnly,
+            object buildConfig,
             object buildConfigDistribution);
     }
 }

--- a/UET/Redpoint.Uet.Configuration/BuildConfigSourceGenerationContext.cs
+++ b/UET/Redpoint.Uet.Configuration/BuildConfigSourceGenerationContext.cs
@@ -33,6 +33,7 @@
                     new BuildConfigTestConverter<BuildConfigProjectDistribution>(serviceProvider),
                     new BuildConfigDeploymentConverter<BuildConfigPluginDistribution>(serviceProvider),
                     new BuildConfigDeploymentConverter<BuildConfigProjectDistribution>(serviceProvider),
+                    new BuildConfigTestPredefinedConverter<BuildConfigPluginDistribution>(serviceProvider),
                     new BuildConfigTargetPlatformConverter(),
                 }
             });

--- a/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigDynamic.cs
+++ b/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigDynamic.cs
@@ -24,6 +24,7 @@
         /// <summary>
         /// If set, this will be emitted as a manual job on build servers. Only applies to deployments. Defaults to false.
         /// </summary>
+        [JsonPropertyName("Manual")]
         public bool? Manual { get; set; }
 
         /// <summary>

--- a/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigDynamicConverterHelpers.cs
+++ b/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigDynamicConverterHelpers.cs
@@ -1,0 +1,208 @@
+﻿namespace Redpoint.Uet.Configuration.Dynamic
+{
+    using System.Text.Json;
+
+    public static class BuildConfigConstants
+    {
+        public const string Predefined = "Predefined";
+    }
+
+    internal static class BuildConfigDynamicConverterHelpers<TDistribution, TBaseClass>
+    {
+        internal static IDynamicProvider<TDistribution, TBaseClass>? ReadAndGetProvider(
+            IDynamicProvider<TDistribution, TBaseClass>[] providers,
+            string noun,
+            string upperNoun,
+            ref Utf8JsonReader readerClone,
+            JsonSerializerOptions options)
+        {
+            if (readerClone.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException($"Expected {noun} entry to be a JSON object.");
+            }
+            while (readerClone.Read())
+            {
+                if (readerClone.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+
+                if (readerClone.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = readerClone.GetString();
+                    readerClone.Read();
+                    if (propertyName == "Type")
+                    {
+                        var propertyValue = readerClone.GetString();
+                        if (propertyValue == BuildConfigConstants.Predefined)
+                        {
+                            return null;
+                        }
+                        if (providers.Length > 0)
+                        {
+                            foreach (var provider in providers)
+                            {
+                                if (provider.Type == propertyValue)
+                                {
+                                    return provider;
+                                }
+                            }
+                            throw new JsonException($"{upperNoun} of type '{propertyValue}' is not recognised as a {noun} provider. Supported {noun} types: {string.Join(", ", providers.Select(x => $"'{x.Type}'"))}");
+                        }
+                        else
+                        {
+                            throw new JsonException($"{upperNoun} of type '{propertyValue}' is not recognised as a {noun} provider. There are no supported {noun} types for this type of BuildConfig.json.");
+                        }
+                    }
+                    else
+                    {
+                        readerClone.TrySkip();
+                    }
+                }
+            }
+            if (providers.Length > 0)
+            {
+                throw new JsonException($"{upperNoun} entry was missing the 'Type' property. It must be set to one of the supported {noun} types: {string.Join(", ", providers.Select(x => $"'{x.Type}'"))}");
+            }
+            else
+            {
+                throw new JsonException($"{upperNoun} entry was missing the 'Type' property. There are no supported {noun} types for this type of BuildConfig.json.");
+            }
+        }
+
+        internal delegate bool ReadIntoDelegate<T>(
+            T result,
+            ref Utf8JsonReader reader,
+            string? propertyName) where T : BuildConfigDynamic<TDistribution, TBaseClass>;
+
+        internal static void ReadInto<T>(
+            T result,
+            IDynamicProvider<TDistribution, TBaseClass>? provider,
+            string noun,
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options,
+            ReadIntoDelegate<T> tryReadInto) where T : BuildConfigDynamic<TDistribution, TBaseClass>
+        {
+            var gotName = false;
+            var gotType = false;
+            var gotDynamicSettings = false;
+
+            var providerType = provider == null /* Predefined */ ? BuildConfigConstants.Predefined : provider.Type;
+
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException($"Expected {noun} entry to be a JSON object.");
+            }
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    var propertyName = reader.GetString();
+                    reader.Read();
+                    switch (propertyName)
+                    {
+                        case "Name":
+                            var name = reader.GetString();
+                            if (name == null)
+                            {
+                                throw new JsonException($"Expected {noun} entry to have a non-null name.");
+                            }
+                            result.Name = name;
+                            gotName = true;
+                            break;
+                        case "Type":
+                            var type = reader.GetString();
+                            if (type == null)
+                            {
+                                throw new JsonException($"Expected {noun} entry to have a non-null type.");
+                            }
+                            result.Type = type;
+                            gotType = true;
+                            break;
+                        case "Manual":
+                            // @todo: Enforce that this can only appear for IDeploymentProvider.
+                            result.Manual = reader.GetBoolean();
+                            break;
+                        default:
+                            if (propertyName == providerType)
+                            {
+                                if (provider == null)
+                                {
+                                    result.DynamicSettings = reader.GetString() ?? string.Empty;
+                                }
+                                else
+                                {
+                                    result.DynamicSettings = provider.DynamicSettings.Deserialize(ref reader);
+                                }
+                                gotDynamicSettings = true;
+                            }
+                            else if (!tryReadInto(result, ref reader, propertyName))
+                            {
+                                // @todo: Make this more accurate for whether 'Manual' can be present.
+                                throw new JsonException($"Unexpected property '{propertyName}' found on {noun} entry. Expected only the properties 'Name', 'Type', '{providerType}' and optionally 'Manual' (only for deployments).");
+                            }
+                            break;
+                    }
+                }
+            }
+
+            if (!gotName)
+            {
+                throw new JsonException($"Expected property 'Name' to be found on {noun} entry.");
+            }
+            if (!gotType)
+            {
+                throw new JsonException($"Expected property 'Type' to be found on {noun} entry.");
+            }
+            if (!gotDynamicSettings)
+            {
+                throw new JsonException($"Expected property '{providerType}' to be found on {noun} entry.");
+            }
+        }
+
+        internal delegate void WriteIntoDelegate<T>(
+            T value,
+            Utf8JsonWriter writer)
+            where T : BuildConfigDynamic<TDistribution, TBaseClass>;
+
+        internal static void WriteInto<T>(
+            IDynamicProvider<TDistribution, TBaseClass>[] providers,
+            T value,
+            Utf8JsonWriter writer,
+            JsonSerializerOptions options,
+            WriteIntoDelegate<T> writeInto)
+            where T : BuildConfigDynamic<TDistribution, TBaseClass>
+        {
+            writer.WriteStartObject();
+
+            writer.WriteString("Name", value.Name);
+            writer.WriteString("Type", value.Type);
+            if (value.Manual.HasValue)
+            {
+                writer.WriteBoolean("Manual", value.Manual.Value);
+            }
+
+            writer.WritePropertyName(value.Type);
+
+            if (value.Type == BuildConfigConstants.Predefined)
+            {
+                writer.WriteStringValue(value.DynamicSettings as string);
+            }
+            else
+            {
+                var provider = providers.First(x => x.Type == value.Type);
+                provider.DynamicSettings.Serialize(writer, value.DynamicSettings);
+            }
+
+            writeInto(value, writer);
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigPredefinedDynamic.cs
+++ b/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigPredefinedDynamic.cs
@@ -1,0 +1,25 @@
+﻿namespace Redpoint.Uet.Configuration.Dynamic
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// A dynamically driven preparation, test or deployment step that is defined outside of a distribution, where dependencies need to be specified.
+    /// </summary>
+    /// <typeparam name="TDistribution">The distribution type, which specifies whether this is for projects or plugins.</typeparam>
+    /// <typeparam name="TBaseClass">The base class for configuration, which specifies whether this is for preparation, tests or deployment.</typeparam>
+    /// <typeparam name="TDependencies">The class that describes the dependencies of this item when not referenced as part of a distribution.</typeparam>
+    public class BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies> : BuildConfigDynamic<TDistribution, TBaseClass>
+    {
+        /// <summary>
+        /// For tests defined outside of distributions, an optional shorter name that can be used with `uet test`.
+        /// </summary>
+        [JsonPropertyName("ShortName")]
+        public string? ShortName { get; set; }
+
+        /// <summary>
+        /// If set, the dependencies that will be processed/required before this entry can be used.
+        /// </summary>
+        [JsonPropertyName("Dependencies")]
+        public TDependencies? Dependencies { get; set; }
+    }
+}

--- a/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigPredefinedDynamicConverter.cs
+++ b/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigPredefinedDynamicConverter.cs
@@ -1,0 +1,95 @@
+﻿namespace Redpoint.Uet.Configuration.Dynamic
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using System.Text.Json.Serialization;
+    using System.Text.Json;
+
+    public abstract class BuildConfigPredefinedDynamicConverter<TDistribution, TBaseClass, TDependencies> : JsonConverter<BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies>>
+    {
+        private readonly IDynamicProvider<TDistribution, TBaseClass>[] _providers;
+
+        protected abstract string Noun { get; }
+
+        private string UpperNoun => Noun[..1].ToUpperInvariant() + Noun[1..];
+
+        protected BuildConfigPredefinedDynamicConverter(IServiceProvider serviceProvider)
+        {
+            _providers = serviceProvider.GetServices<IDynamicProvider<TDistribution, TBaseClass>>().ToArray();
+        }
+
+        public override BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies>? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            IDynamicProvider<TDistribution, TBaseClass>? provider;
+            {
+                var readerClone = reader;
+                provider = BuildConfigDynamicConverterHelpers<TDistribution, TBaseClass>.ReadAndGetProvider(
+                    _providers,
+                    Noun,
+                    UpperNoun,
+                    ref readerClone,
+                    options);
+            }
+
+            var result = new BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies>();
+            BuildConfigDynamicConverterHelpers<TDistribution, TBaseClass>.ReadInto(
+                result,
+                provider,
+                Noun,
+                ref reader,
+                typeToConvert,
+                options,
+                (BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies> result, ref Utf8JsonReader reader, string? propertyName) =>
+                {
+                    switch (propertyName)
+                    {
+                        case "ShortName":
+                            var shortName = reader.GetString();
+                            if (shortName == null)
+                            {
+                                throw new JsonException($"Expected {Noun} entry to have a non-null name.");
+                            }
+                            result.ShortName = shortName;
+                            return true;
+                        case "Dependencies":
+                            result.Dependencies = (TDependencies?)JsonSerializer.Deserialize(ref reader, options.GetTypeInfo(typeof(TDependencies)));
+                            return true;
+                        default:
+                            return false;
+                    }
+                });
+
+            return result;
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies> value,
+            JsonSerializerOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(writer);
+            ArgumentNullException.ThrowIfNull(value);
+
+            BuildConfigDynamicConverterHelpers<TDistribution, TBaseClass>.WriteInto(
+                _providers,
+                value,
+                writer,
+                options,
+                (BuildConfigPredefinedDynamic<TDistribution, TBaseClass, TDependencies> value, Utf8JsonWriter writer) =>
+                {
+                    if (!string.IsNullOrWhiteSpace(value.ShortName))
+                    {
+                        writer.WriteString("ShortName", value.ShortName);
+                    }
+
+                    if (value.Dependencies != null)
+                    {
+                        writer.WritePropertyName("Dependencies");
+                        JsonSerializer.Serialize(writer, value.Dependencies, options.GetTypeInfo(typeof(TDependencies)));
+                    }
+                });
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigTestPredefinedConverter.cs
+++ b/UET/Redpoint.Uet.Configuration/Dynamic/BuildConfigTestPredefinedConverter.cs
@@ -1,0 +1,13 @@
+﻿namespace Redpoint.Uet.Configuration.Dynamic
+{
+    using Redpoint.Uet.Configuration.Plugin;
+
+    internal sealed class BuildConfigTestPredefinedConverter<TDistribution> : BuildConfigPredefinedDynamicConverter<TDistribution, ITestProvider, BuildConfigPluginPredefinedTestDependencies>
+    {
+        public BuildConfigTestPredefinedConverter(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+        }
+
+        protected override string Noun => "test";
+    }
+}

--- a/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPlugin.cs
+++ b/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPlugin.cs
@@ -1,5 +1,6 @@
 ﻿namespace Redpoint.Uet.Configuration.Plugin
 {
+    using Redpoint.Uet.Configuration.Dynamic;
     using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
 
@@ -16,6 +17,13 @@
         /// </summary>
         [JsonPropertyName("Copyright"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public BuildConfigPluginCopyright? Copyright { get; set; }
+
+        /// <summary>
+        /// A list of predefined tests that you can use with `uet test` or in other "Tests" sections for distributions.
+        /// </summary>
+        [JsonPropertyName("Tests"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "This property is used for JSON serialization.")]
+        public BuildConfigPredefinedDynamic<BuildConfigPluginDistribution, ITestProvider, BuildConfigPluginPredefinedTestDependencies>[]? Tests { get; set; }
 
         /// <summary>
         /// A list of distributions.

--- a/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPluginPredefinedTestDependencies.cs
+++ b/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPluginPredefinedTestDependencies.cs
@@ -1,0 +1,28 @@
+﻿namespace Redpoint.Uet.Configuration.Plugin
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Specifies how to how to package and build the plugin so this test can be run.
+    /// </summary>
+    public class BuildConfigPluginPredefinedTestDependencies
+    {
+        /// <summary>
+        /// A list of environment variables to set during the build.
+        /// </summary>
+        [JsonPropertyName("EnvironmentVariables"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Dictionary<string, string>? EnvironmentVariables { get; set; }
+
+        /// <summary>
+        /// Specifies how to build the plugin to test it.
+        /// </summary>
+        [JsonPropertyName("Build"), JsonRequired]
+        public BuildConfigPluginBuild? Build { get; set; }
+
+        /// <summary>
+        /// Specifies how to package the plugin in order to test it.
+        /// </summary>
+        [JsonPropertyName("Package"), JsonRequired]
+        public BuildConfigPluginPackage? Package { get; set; }
+    }
+}

--- a/UET/uet/Commands/Build/BuildCommand.cs
+++ b/UET/uet/Commands/Build/BuildCommand.cs
@@ -476,6 +476,7 @@
                                     buildSpec = await _buildSpecificationGenerator.BuildConfigProjectToBuildSpecAsync(
                                         engineSpec,
                                         buildGraphEnvironment,
+                                        (BuildConfigProject)distribution.BuildConfig,
                                         projectDistribution,
                                         repositoryRoot: path.DirectoryPath,
                                         executeBuild: true,
@@ -495,11 +496,12 @@
                                     buildSpec = await _buildSpecificationGenerator.BuildConfigPluginToBuildSpecAsync(
                                         engineSpec,
                                         buildGraphEnvironment,
-                                        pluginDistribution,
                                         (BuildConfigPlugin)distribution.BuildConfig,
+                                        pluginDistribution,
                                         repositoryRoot: path.DirectoryPath,
                                         executeBuild: true,
                                         executePackage: true,
+                                        executeZip: true,
                                         executeTests: test,
                                         executeDeployment: deploy,
                                         strictIncludes: strictIncludes,

--- a/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
@@ -310,6 +310,7 @@
         private async Task<(string nodeInclude, string macroInclude)> WriteDynamicBuildGraphIncludeAsync(
             BuildGraphEnvironment env,
             bool localExecutor,
+            object buildConfig,
             object distribution,
             bool executeTests,
             bool executeDeployment)
@@ -327,6 +328,7 @@
                 await _dynamicBuildGraphIncludeWriter.WriteBuildGraphNodeInclude(
                     stream,
                     localExecutor,
+                    buildConfig,
                     distribution,
                     executeTests,
                     executeDeployment).ConfigureAwait(false);
@@ -338,6 +340,7 @@
                 await _dynamicBuildGraphIncludeWriter.WriteBuildGraphMacroInclude(
                     stream,
                     localExecutor,
+                    buildConfig,
                     distribution).ConfigureAwait(false);
             }
             await _worldPermissionApplier.GrantEveryonePermissionAsync(Path.Combine(sharedStorageAbsolutePath, macroFilename), CancellationToken.None).ConfigureAwait(false);
@@ -348,11 +351,12 @@
         public async Task<BuildSpecification> BuildConfigPluginToBuildSpecAsync(
             BuildEngineSpecification engineSpec,
             BuildGraphEnvironment buildGraphEnvironment,
-            BuildConfigPluginDistribution distribution,
             BuildConfigPlugin pluginInfo,
+            BuildConfigPluginDistribution distribution,
             string repositoryRoot,
             bool executeBuild,
             bool executePackage,
+            bool executeZip,
             bool executeTests,
             bool executeDeployment,
             bool strictIncludes,
@@ -448,6 +452,7 @@
             var (scriptNodeIncludes, scriptMacroIncludes) = await WriteDynamicBuildGraphIncludeAsync(
                 buildGraphEnvironment,
                 localExecutor,
+                pluginInfo,
                 distribution,
                 executeTests,
                 executeDeployment).ConfigureAwait(false);
@@ -547,6 +552,7 @@
 
                     // Package options
                     { $"ExecutePackage", executePackage ? "true" : "false" },
+                    { $"ExecuteZip", executeZip ? "true" : "false" },
                     { "VersionNumber", versionInfo.versionNumber },
                     { "VersionName", versionInfo.versionName },
                     { "PackageFolder", distribution.Package?.OutputFolderName ?? "Packaged" },
@@ -569,6 +575,7 @@
         public async Task<BuildSpecification> BuildConfigProjectToBuildSpecAsync(
             BuildEngineSpecification engineSpec,
             BuildGraphEnvironment buildGraphEnvironment,
+            BuildConfigProject buildConfig,
             BuildConfigProjectDistribution distribution,
             string repositoryRoot,
             bool executeBuild,
@@ -588,6 +595,7 @@
             var (scriptNodeIncludes, scriptMacroIncludes) = await WriteDynamicBuildGraphIncludeAsync(
                 buildGraphEnvironment,
                 localExecutor,
+                buildConfig,
                 distribution,
                 executeTests,
                 executeDeployment).ConfigureAwait(false);
@@ -746,6 +754,7 @@
 
                     // Package options
                     { $"ExecutePackage", package ? "true" : "false" },
+                    { $"ExecuteZip", "true" },
                     { "VersionNumber", versionInfo.versionNumber },
                     { "VersionName", versionInfo.versionName },
                     { "PackageFolder", packageType.ToString() },

--- a/UET/uet/Commands/Build/IBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/IBuildSpecificationGenerator.cs
@@ -12,6 +12,7 @@
         Task<BuildSpecification> BuildConfigProjectToBuildSpecAsync(
             BuildEngineSpecification engineSpec,
             BuildGraphEnvironment buildGraphEnvironment,
+            BuildConfigProject buildConfig,
             BuildConfigProjectDistribution distribution,
             string repositoryRoot,
             bool executeBuild,
@@ -24,11 +25,12 @@
         Task<BuildSpecification> BuildConfigPluginToBuildSpecAsync(
             BuildEngineSpecification engineSpec,
             BuildGraphEnvironment buildGraphEnvironment,
+            BuildConfigPlugin buildConfig,
             BuildConfigPluginDistribution distribution,
-            BuildConfigPlugin pluginInfo,
             string repositoryRoot,
             bool executeBuild,
             bool executePackage,
+            bool executeZip,
             bool executeTests,
             bool executeDeployment,
             bool strictIncludes,

--- a/UET/uet/Commands/Internal/GenerateJsonSchema/DefaultJsonSchemaGenerator.cs
+++ b/UET/uet/Commands/Internal/GenerateJsonSchema/DefaultJsonSchemaGenerator.cs
@@ -163,6 +163,7 @@
                 {
                     writer.WriteStringValue(type);
                 }
+                writer.WriteStringValue(BuildConfigConstants.Predefined);
                 writer.WriteEndArray();
             }
 
@@ -278,6 +279,7 @@
                     writer.WriteEndArray();
                     writer.WritePropertyName("properties");
                     writer.WriteStartObject();
+                    writer.WriteBoolean(BuildConfigConstants.Predefined, false);
                     foreach (var otherProvider in providers.Where(x => ((IDynamicProviderRegistration)x).Type != ((IDynamicProviderRegistration)type).Type))
                     {
                         writer.WriteBoolean(((IDynamicProviderRegistration)otherProvider).Type, false);
@@ -302,6 +304,39 @@
                         }
                         writer.WriteEndArray();
                     }
+                    writer.WriteEndObject();
+                    writer.WriteEndObject();
+                    writer.WriteEndObject();
+                    writer.WriteEndObject();
+                }
+                {
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("if");
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("properties");
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("Type");
+                    writer.WriteStartObject();
+                    writer.WriteString("const", BuildConfigConstants.Predefined);
+                    writer.WriteEndObject();
+                    writer.WriteEndObject();
+                    writer.WriteEndObject();
+                    writer.WritePropertyName("then");
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("required");
+                    writer.WriteStartArray();
+                    writer.WriteStringValue(BuildConfigConstants.Predefined);
+                    writer.WriteEndArray();
+                    writer.WritePropertyName("properties");
+                    writer.WriteStartObject();
+                    foreach (var otherProvider in providers)
+                    {
+                        writer.WriteBoolean(((IDynamicProviderRegistration)otherProvider).Type, false);
+                    }
+                    writer.WritePropertyName(BuildConfigConstants.Predefined);
+                    writer.WriteStartObject();
+                    writer.WriteString("type", "string");
+                    writer.WriteString("description", "The predefined name defined earlier in configuration.");
                     writer.WriteEndObject();
                     writer.WriteEndObject();
                     writer.WriteEndObject();


### PR DESCRIPTION
This adds support for "predefined" tests in `BuildConfig.json` files for plugins:

```jsonc
{
  "Type": "Plugin",
  "Tests": [
    {
      "Name": "Test Name",
      "ShortName": "tn",
      "Type": "Custom",
      "Custom": {
        // ...
      },
      "Dependencies": {
        "Package": {
          // Same as "Package" in distributions...
        },
        "Build": {
          // Same as "Build" in distributions...
        }
      }
    }
  ],
  "Distributions": [
    {
      "Name": "Distribution",
      // ...
      "Tests": [
        {
          "Name": "License Key Validation",
          "Type": "Predefined",
          "Predefined": "License Key Validation"
        }
      ]
    }
  ]
}
```

Predefined tests can be used in two ways:

- Referenced in the `Tests` array for a distribution, by setting `Type` to "Predefined" and `Predefined` to the name of the predefined test. If you're using the same test in multiple distributions, this reduces the amount of copy-paste/duplication you'd otherwise need.
- Used when running `uet test` in a folder that contains `BuildConfig.json`, by passing `--name|-n` where the passed value is equal to either the name or short name of the predefined test.

The `Dependencies` of a predefined test is only used for `uet test` (where there is no packaging/build information coming from a distribution).