### PR TITLE
Fix code analyzer errors that haven't been silenced.

### DIFF
--- a/UET/Redpoint.SelfVersion/RedpointSelfVersion.cs
+++ b/UET/Redpoint.SelfVersion/RedpointSelfVersion.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 internal class RedpointSelfVersion
 {
-    [return: NotNullIfNotNull("attribute")]
+    [return: NotNullIfNotNull(nameof(attribute))]
     public static string? GetInformationalVersion(AssemblyInformationalVersionAttribute? attribute)
     {
         if (attribute == null)

--- a/UET/Redpoint.Uet.SdkManagement/Sdk/MacSdkSetup.cs
+++ b/UET/Redpoint.Uet.SdkManagement/Sdk/MacSdkSetup.cs
@@ -213,8 +213,7 @@
                 _logger.LogInformation($"Setting up symbolic link for Xcode.app...");
                 var xcodeDirectory = Directory.GetDirectories(sdkPackagePath)
                     .Select(x => Path.GetFileName(x))
-                    .Where(x => x.StartsWith("Xcode", StringComparison.Ordinal))
-                    .First();
+                    .First(x => x.StartsWith("Xcode", StringComparison.Ordinal));
                 File.CreateSymbolicLink(
                     Path.Combine(sdkPackagePath, "Xcode.app"),
                     xcodeDirectory);

--- a/UET/uet/Commands/Internal/UpdateUPlugin/UpdateUPluginCommand.cs
+++ b/UET/uet/Commands/Internal/UpdateUPlugin/UpdateUPluginCommand.cs
@@ -98,10 +98,7 @@
                 else
                 {
                     var obj = node.AsObject();
-                    if (obj.ContainsKey("EnabledByDefault"))
-                    {
-                        obj.Remove("EnabledByDefault");
-                    }
+                    obj.Remove("EnabledByDefault");
 
                     foreach (var module in node["Modules"]?.AsArray() ?? new JsonArray())
                     {


### PR DESCRIPTION
- MacSdkSetup.cs: error IDE0120: Simplify LINQ expression
- RedpointSelfVersion.cs: error IDE0280: Use 'nameof'
- UpdateUPluginCommand.cs: error CA1853: Do not guard 'Dictionary.Remove(key)' with 'Dictionary.ContainsKey(key)'