### PR TITLE
Mark GitLab jobs as interruptable

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Executors.GitLab/GitLabBuildExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Executors.GitLab/GitLabBuildExecutor.cs
@@ -58,6 +58,9 @@
                 job.Variables = new Dictionary<string, string>(sourceJob.EnvironmentVariables);
                 job.Needs = sourceJob.Agent.IsManual ? new List<string>() : sourceJob.Needs.ToList();
 
+                // Ensure that older jobs are stopped when replaced with newer ones.
+                job.Interruptible = true;
+
                 if (sourceJob.Agent.Platform == BuildServerJobPlatform.Windows)
                 {
                     job.Tags = new List<string> { "buildgraph-windows" };


### PR DESCRIPTION
This will make GitLab cancel jobs when they are no longer relevant (such as a new commit being pushed to a merge request).