### PR TITLE
Ensure Binaries and StagedBuilds folder for Android gets cleaned pre-build

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/PreBuild/DefaultPreBuild.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/PreBuild/DefaultPreBuild.cs
@@ -29,16 +29,31 @@
             }
 
             var components = nodeName.Split(' ');
-            if (!components.Contains("MetaQuest") &&
-                !components.Contains("GooglePlay"))
+
+            // Figure out what Android platforms we would need to clean for this job.
+            var androidPlatformNames = new HashSet<string>();
+            if (components.Contains("Android") ||
+                components.Contains("MetaQuest") ||
+                components.Contains("GooglePlay"))
             {
-                // Not a node that would be affected by stale Android files.
+                androidPlatformNames.Add("Android");
+            }
+            if (components.Contains("MetaQuest"))
+            {
+                androidPlatformNames.Add("MetaQuest");
+            }
+            if (components.Contains("GooglePlay"))
+            {
+                androidPlatformNames.Add("GooglePlay");
+            }
+
+            // If this job isn't affected by Android platforms, we don't need to do anything.
+            if (androidPlatformNames.Count == 0)
+            {
                 return Task.FromResult(0);
             }
-            var platformName = components.Contains("MetaQuest") ? "MetaQuest" : "GooglePlay";
 
             // We need to clear out 'Binaries/' and 'Saved/StagedBuilds/' of potential stale folders.
-            var androidPlatformNames = new[] { "Android", platformName };
             var binariesFolder = new DirectoryInfo(Path.Combine(projectRoot, "Binaries"));
             var stagedBuildsFolder = new DirectoryInfo(Path.Combine(projectRoot, "Saved", "StagedBuilds"));
             if (binariesFolder.Exists)


### PR DESCRIPTION
This cleans just the Android folder under Binaries and StagedBuilds when building for Android (in addition to the existing clean rules we have for MetaQuest and GooglePlay). This prevents stale build files from being tagged during Android builds.

This should fix the "stale files being tagged" issue that was mentioned in #82.