### PR TITLE
Delete the Gradle 'transforms-4' cache folder before each build

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/DefaultBuildGraphExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/DefaultBuildGraphExecutor.cs
@@ -98,6 +98,23 @@
                     Name = "GradleUserHome"
                 }, cancellationToken).ConfigureAwait(false)).AsAsyncDisposable(out var gradleUserHome).ConfigureAwait(false))
                 {
+                    // Delete the Gradle 'tarnsforms-4' cache folder, since it can become corrupt and then prevent
+                    // any further Android build jobs from working on this machine.
+                    var transformsFolder = Path.Combine(gradleUserHome.Path, "caches", "transforms-4");
+                    if (Directory.Exists(transformsFolder))
+                    {
+                        _logger.LogInformation("Deleting Gradle 'transforms-4' cache...");
+                        try
+                        {
+                            await DirectoryAsync.DeleteAsync(transformsFolder, true);
+                            _logger.LogInformation("Successfully deleted Gradle 'transforms-4' cache.");
+                        }
+                        catch
+                        {
+                            _logger.LogWarning("Failed to delete Gradle 'transforms-4' cache.");
+                        }
+                    }
+
                     var environmentVariables = new Dictionary<string, string>
                     {
                         { "IsBuildMachine", "1" },


### PR DESCRIPTION
This folder can become corrupt and then prevent any further Android builds from succeeding on a machine. Just delete the 'transforms-4' cache folder before each build.