### PR TITLE
Run reparent-additional-properties-in-targets for Pak and Stage in project builds

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Project.xml
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Project.xml
@@ -405,6 +405,9 @@
             Value="$(BCRArgs) -ini:Engine:[/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]:bPackageForMetaQuest=False" />
         </Do>
 
+        <!-- Run our reparenting hook, which is necessary to fix up Android UPL paths when not building against a source engine. -->
+        <Spawn Exe="$(UETPath)" Arguments="$(UETGlobalArgs) internal reparent-additional-properties-in-targets --project-directory-path &quot;$(ProjectPath)&quot;" />
+
         <!-- Execute the BuildCookRun command with all the desired arguments. -->
         <Command Name="BuildCookRun" Arguments="&quot;-project=$(UProjectPath)&quot; -nop4 -SkipCook -cook -pak -stage &quot;-stagingdirectory=$(StageDirectory)&quot; -unattended -stdlog -target=$(TargetName) $(BCRArgs)" />
 


### PR DESCRIPTION
This fixes up Android project builds distributed through BuildGraph when the project contains a plugin with UPL files.