### PR TITLE
Skip rebuilding UBT when using a source-based engine

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/DefaultBuildGraphPatcher.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/DefaultBuildGraphPatcher.cs
@@ -268,6 +268,14 @@
                 return;
             }
 
+            if (!Path.Exists(Path.Combine(enginePath, "Engine", "Build", "InstalledBuild.txt")))
+            {
+                // If this is not an installed build (the engine is source code), even if we're not doing an
+                // engine build, we don't need to build UBT after patching because running UAT will cause the
+                // necessary binaries to be rebuilt if they're out-of-date.
+                return;
+            }
+
             await CopyMissingEngineBitsAsync(enginePath).ConfigureAwait(false);
 
             var epicGamesCoreProject = Path.Combine(enginePath, "Engine", "Source", "Programs", "Shared", "EpicGames.Core", "EpicGames.Core.csproj");


### PR DESCRIPTION
If we're using a source-based engine, RunUAT will already rebuild UBT and associated binaries if they're out-of-date when we start BuildGraph.