### PR TITLE
Force `lf` line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Users that have configured `core.autocrlf=true` will check out the project with `crlf` line endings. This causes inconsistencies in the working tree because `.editorconfig` specifies new line ending should be `lf`.

Given the project is almost entirely encoded with `lf` and the editorconfig file, it makes sense to force this during checkout as well. This change overrides the user's preference locally and ensures line endings are consistent in the working tree.