### PR TITLE
Make Redpoint.CloudFramework depend on analyzer + CLI in NuGet package

### DIFF
--- a/UET/Redpoint.CloudFramework.Abstractions/IWebAppProvider.cs
+++ b/UET/Redpoint.CloudFramework.Abstractions/IWebAppProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Redpoint.CloudFramework.Startup
+﻿namespace Redpoint.CloudFramework.Abstractions
 {
     using Microsoft.AspNetCore.Hosting;
     using System.Threading.Tasks;

--- a/UET/Redpoint.CloudFramework.Abstractions/Redpoint.CloudFramework.Abstractions.csproj
+++ b/UET/Redpoint.CloudFramework.Abstractions/Redpoint.CloudFramework.Abstractions.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)../Lib/Common.Build.props" />
+
+  <Import Project="$(MSBuildThisFileDirectory)../Lib/LibraryPackaging.Build.props" />
+  <PropertyGroup>
+    <Description>Common interfaces shared between the runtime library and CLI tooling.</Description>
+    <PackageTags>cloud, framework, abstractions</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/UET/Redpoint.CloudFramework.CLI/GenerateOpenApiJson.cs
+++ b/UET/Redpoint.CloudFramework.CLI/GenerateOpenApiJson.cs
@@ -4,7 +4,7 @@
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.OpenApi.Writers;
-    using Redpoint.CloudFramework.Startup;
+    using Redpoint.CloudFramework.Abstractions;
     using Redpoint.CommandLine;
     using Swashbuckle.AspNetCore.Swagger;
     using System;

--- a/UET/Redpoint.CloudFramework.CLI/Redpoint.CloudFramework.CLI.csproj
+++ b/UET/Redpoint.CloudFramework.CLI/Redpoint.CloudFramework.CLI.csproj
@@ -34,7 +34,7 @@
       <Aliases>RDCommandLine</Aliases>
     </ProjectReference>
     <ProjectReference Include="..\Lib\Redpoint.ThirdParty.System.CommandLine\Redpoint.ThirdParty.System.CommandLine.csproj" />
-    <ProjectReference Include="..\Redpoint.CloudFramework\Redpoint.CloudFramework.csproj" />
+    <ProjectReference Include="..\Redpoint.CloudFramework.Abstractions\Redpoint.CloudFramework.Abstractions.csproj" />
     <ProjectReference Include="..\Redpoint.CommandLine\Redpoint.CommandLine.csproj" />
     <ProjectReference Include="..\Redpoint.Logging.SingleLine\Redpoint.Logging.SingleLine.csproj" />
     <ProjectReference Include="..\Redpoint.PathResolution\Redpoint.PathResolution.csproj" />

--- a/UET/Redpoint.CloudFramework/Redpoint.CloudFramework.csproj
+++ b/UET/Redpoint.CloudFramework/Redpoint.CloudFramework.csproj
@@ -48,10 +48,22 @@
     <ProjectReference Include="..\Lib\Redpoint.ThirdParty.React.AspNet\Redpoint.ThirdParty.React.AspNet.csproj" />
     <ProjectReference Include="..\Lib\Redpoint.ThirdParty.React.Core\Redpoint.ThirdParty.React.Core.csproj" />
     <ProjectReference Include="..\Lib\Redpoint.ThirdParty.System.CommandLine\Redpoint.ThirdParty.System.CommandLine.csproj" />
+    <ProjectReference Include="..\Redpoint.CloudFramework.Abstractions\Redpoint.CloudFramework.Abstractions.csproj" />
     <ProjectReference Include="..\Redpoint.Collections\Redpoint.Collections.csproj" />
     <ProjectReference Include="..\Redpoint.Concurrency\Redpoint.Concurrency.csproj" />
     <ProjectReference Include="..\Redpoint.Logging.SingleLine\Redpoint.Logging.SingleLine.csproj" />
     <ProjectReference Include="..\Redpoint.StringEnum\Redpoint.StringEnum.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Redpoint.CloudFramework.Analyzer.Package\Redpoint.CloudFramework.Analyzer.Package.csproj">
+      <IncludeAssets>analyzers;build</IncludeAssets>
+      <PrivateAssets>none</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Redpoint.CloudFramework.CLI\Redpoint.CloudFramework.CLI.csproj">
+      <IncludeAssets>build;buildMultiTargeting;buildTransitive</IncludeAssets>
+      <PrivateAssets>none</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/UET/Redpoint.CloudFramework/Startup/DefaultWebAppConfigurator.cs
+++ b/UET/Redpoint.CloudFramework/Startup/DefaultWebAppConfigurator.cs
@@ -11,6 +11,7 @@
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Quartz;
+    using Redpoint.CloudFramework.Abstractions;
     using Redpoint.CloudFramework.DataProtection;
     using Redpoint.CloudFramework.Locking;
     using Redpoint.CloudFramework.Prefix;

--- a/UET/Redpoint.CloudFramework/Startup/IWebAppConfigurator.cs
+++ b/UET/Redpoint.CloudFramework/Startup/IWebAppConfigurator.cs
@@ -3,6 +3,7 @@
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Quartz;
+    using Redpoint.CloudFramework.Abstractions;
     using Redpoint.CloudFramework.Processor;
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/UET/UET.sln
+++ b/UET/UET.sln
@@ -337,6 +337,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.CloudFramework.Ana
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.CloudFramework.Analyzer.Tests", "Redpoint.CloudFramework.Analyzer.Tests\Redpoint.CloudFramework.Analyzer.Tests.csproj", "{1078157C-2CCD-4A35-9910-2880C2E7EC03}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.CloudFramework.Abstractions", "Redpoint.CloudFramework.Abstractions\Redpoint.CloudFramework.Abstractions.csproj", "{EA5480E2-6C5D-48B9-87A9-16351DF4DCC1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -919,6 +921,10 @@ Global
 		{1078157C-2CCD-4A35-9910-2880C2E7EC03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1078157C-2CCD-4A35-9910-2880C2E7EC03}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1078157C-2CCD-4A35-9910-2880C2E7EC03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA5480E2-6C5D-48B9-87A9-16351DF4DCC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA5480E2-6C5D-48B9-87A9-16351DF4DCC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA5480E2-6C5D-48B9-87A9-16351DF4DCC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA5480E2-6C5D-48B9-87A9-16351DF4DCC1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1038,6 +1044,7 @@ Global
 		{A0A63A95-390D-494F-8AC0-7D0B0836770D} = {A93D92E5-865B-4681-AC53-4B1689F1B3E8}
 		{C303BBC5-B739-45DB-A1DC-DFCA71DAA1C5} = {A93D92E5-865B-4681-AC53-4B1689F1B3E8}
 		{1078157C-2CCD-4A35-9910-2880C2E7EC03} = {A93D92E5-865B-4681-AC53-4B1689F1B3E8}
+		{EA5480E2-6C5D-48B9-87A9-16351DF4DCC1} = {A93D92E5-865B-4681-AC53-4B1689F1B3E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8598A278-509A-48A6-A7B3-3E3B0D1011F1}


### PR DESCRIPTION
So that downstream projects only need to consume Redpoint.CloudFramework to get the analyzer and tooling