### PR TITLE
Enable PublishReadyToRun on macOS again

### DIFF
--- a/UET/Lib/Executable.Build.props
+++ b/UET/Lib/Executable.Build.props
@@ -7,11 +7,10 @@
     <RuntimeIdentifiers>win-x64;osx-arm64;linux-x64</RuntimeIdentifiers>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!-- 
-      PublishReadyToRun on macOS is impacted by bug https://github.com/dotnet/runtime/issues/88288, so
-      we turn off ReadyToRun for macOS binaries.
+      The PublishReadyToRun bug on macOS (https://github.com/dotnet/runtime/issues/88288) is 
+      reportedly fixed in .NET 9. If this bug happens again, the issue needs to be re-opened.
     -->
-    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != 'osx-arm64'">true</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">false</PublishReadyToRun>
+    <PublishReadyToRun>true</PublishReadyToRun>
     <PublishTrimmed>true</PublishTrimmed>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <DebuggerSupport Condition="'$(Configuration)' == 'Release'">false</DebuggerSupport>


### PR DESCRIPTION
This bug is reportedly fixed in .NET 9 and this flag should make UET start up faster on macOS.