### PR TITLE
Fix slow build caused by analyzers on Redpoint.Uet.SdkManagement

### DIFF
--- a/UET/Redpoint.Uet.SdkManagement/Redpoint.Uet.SdkManagement.csproj
+++ b/UET/Redpoint.Uet.SdkManagement/Redpoint.Uet.SdkManagement.csproj
@@ -11,4 +11,13 @@
     <ProjectReference Include="..\Redpoint.Uet.Core\Redpoint.Uet.Core.csproj" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!--
+      There's some analyzer that *really* doesn't like the code in this assembly and 
+      stalls the build out by several minutes while it sits there and does nothing. 
+      We have to turn off analyzers-during-build for this assembly. 
+    -->
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
I tried using the VS profiler to see exactly what analyzer was causing this, but the only detail I could see is some kind of "data flow" analysis.