### PR TITLE
Fix UET shim reading product version of current UET binary

### DIFF
--- a/UET/uet.shim/Program.cs
+++ b/UET/uet.shim/Program.cs
@@ -70,6 +70,10 @@ await using (services.BuildServiceProvider().AsAsyncDisposable(out var sp).Confi
     if (string.IsNullOrEmpty(targetVersion) && File.Exists(UpgradeCommandImplementation.GetAssemblyPathForVersion("Current")))
     {
         targetVersion = FileVersionInfo.GetVersionInfo(UpgradeCommandImplementation.GetAssemblyPathForVersion("Current")).ProductVersion;
+        if (targetVersion != null && targetVersion.Contains('+', StringComparison.InvariantCulture))
+        {
+            targetVersion = targetVersion.Split('+')[0];
+        }
         if (!string.IsNullOrEmpty(targetVersion))
         {
             logger.LogInformation($"UET shim selected version {targetVersion} from current installations.");


### PR DESCRIPTION
Builds of UET now include the Git commit as part of the 'ProductVersion' that gets embedded into the binary. This strips off the commit part (after the + character if present) so that the retrieved version number matches the format that UET expects.