### PR TITLE
Set FixNamespaceComments to false by default

### DIFF
--- a/UET/uet/Commands/Format/FormatCommand.cs
+++ b/UET/uet/Commands/Format/FormatCommand.cs
@@ -193,6 +193,7 @@ AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AlignAfterOpenBracket: AlwaysBreak
 BreakConstructorInitializers: BeforeComma
+FixNamespaceComments: false
 ---
 ");
                         }


### PR DESCRIPTION
clang-format's "FixNamespaceComments" setting does not behave correctly if the namespace is longer than the line character limit. Turn this setting off by default.