### PR TITLE
Add support for requiring packages in custom project deployment provider.

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/BuildConfigProjectDeploymentCustom.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/BuildConfigProjectDeploymentCustom.cs
@@ -1,5 +1,7 @@
 ﻿namespace Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Custom
 {
+    using Package;
+    using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
 
     public class BuildConfigProjectDeploymentCustom
@@ -12,5 +14,13 @@
         /// </summary>
         [JsonPropertyName("ScriptPath"), JsonRequired]
         public string ScriptPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Specifies the packaging targets to obtain for deployment.
+        /// If not specified, all targets are obtained.
+        /// </summary>
+        [JsonPropertyName("Packages")]
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "This property is used for JSON serialization.")]
+        public BuildConfigProjectDeploymentPackage[]? Packages { get; set; }
     }
 }

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/CustomProjectDeploymentProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/Custom/CustomProjectDeploymentProvider.cs
@@ -27,13 +27,25 @@
 
             foreach (var deployment in castedSettings)
             {
+                string requiredFiles;
+                if (deployment.settings.Packages != null)
+                {
+                    // Obtain staged files for all desired packages.
+                    requiredFiles = deployment.settings.Packages.Aggregate("", (current, package) => current + $"#{package.Type}Staged_{package.Target}_{package.Platform}_{package.Configuration};") + "$(DynamicPreDeploymentNodes)";
+                }
+                else
+                {
+                    // If no packages are specified (also, for backwards compatibility), obtain all staged files.
+                    requiredFiles = "$(GameStaged);$(ClientStaged);$(ServerStaged);$(DynamicPreDeploymentNodes)";
+                }
+
                 await writer.WriteAgentNodeAsync(
                     new AgentNodeElementProperties
                     {
                         AgentStage = $"Deployment {deployment.name}",
                         AgentType = deployment.manual ? "Win64_Manual" : "Win64",
                         NodeName = $"Deployment {deployment.name}",
-                        Requires = $"$(GameStaged);$(ClientStaged);$(ServerStaged);$(DynamicPreDeploymentNodes)",
+                        Requires = requiredFiles,
                     },
                     async writer =>
                     {


### PR DESCRIPTION
Implemented based on your suggestion to use `BuildConfigProjectDeploymentPackage`, but implemented as an array so you can choose to require multiple packages (e.g. Client + Server builds) and deploy them together (e.g. zip up and archive to shared storage).

resolves #167