### PR TITLE
Add "StripDebugSymbols" options to plugin builds

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
@@ -72,6 +72,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"MacPlatforms", $"IOS;Mac" },
                     { $"StrictIncludes", $"false" },
                     { $"StageDirectory", $"__REPOSITORY_ROOT__/Saved/StagedBuilds" },
+                    { "StripDebugSymbols", "false" },
                 },
                 new Dictionary<string, string>
                 {
@@ -128,7 +129,6 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"ServerConfigurations", $"" },
                     { $"MacPlatforms", $"IOS;Mac" },
                     { $"StrictIncludes", $"false" },
-                    { $"Allow2019", $"false" },
                     { $"EnginePrefix", $"Unreal" },
                     { $"ExecutePackage", $"false" },
                     { $"ExecuteZip", $"false" },
@@ -140,6 +140,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"PackageType", $"Generic" },
                     { $"CopyrightHeader", $"" },
                     { $"CopyrightExcludes", $"" },
+                    { "StripDebugSymbols", "false" },
                 },
                 new Dictionary<string, string>
                 {

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
@@ -29,8 +29,8 @@
   <Option Name="MacPlatforms" Restrict="[^ ]*" DefaultValue="Mac;IOS" Description="List of platforms that macOS agents should build instead of Windows, e.g. Mac;IOS" />
   <Option Name="StrictIncludes" Restrict="true|false" DefaultValue="false" Description="If enabled, builds with strict includes turned on (must pass strict include checks for Marketplace/Fab submission)" />
   <Option Name="EnginePrefix" Restrict="UE4|Unreal" DefaultValue="UE4" Description="Prefix of the engine targets (UE5 has a different prefix)" />
-  <Option Name="Allow2019" Restrict="true|false" DefaultValue="false" Description="If true, the plugin will be built with the latest version of Visual Studio, instead of Visual Studio 2017" />
   <Option Name="ExecuteBuild" Restrict="true|false" DefaultValue="true" Description="If false, no build steps are run (currently ignored)" />
+  <Option Name="StripDebugSymbols" Restrict="true|false" DefaultValue="false" Description="If true, debugging symbols are stripped and not present" />
 
   <!-- Package options -->
   <Option Name="VersionNumber" Restrict="[0-9]+" DefaultValue="10000" Description="The version number to embed in the packaged .uplugin file" />
@@ -52,8 +52,6 @@
   <Option Name="ScriptNodeIncludes" DefaultValue="" Description="Additional script includes paths for nodes" />
   <Option Name="ScriptMacroIncludes" DefaultValue="" Description="Additional script includes paths for macros" />
 
-  <Property Name="2017Flag" Value="-2017" />
-  <Property Name="2017Flag" Value="" If="'$(Allow2019)' == 'true'" />
   <Property Name="EditorBinaries" Value="" />
   <Property Name="GameBinaries" Value="" />
   <Property Name="AdditionalArguments" Value=" -DisableAdaptiveUnity" If="'$(StrictIncludes)' == 'false'" />
@@ -72,6 +70,8 @@
   <Property Name="DynamicPreDeploymentNodes" Value="" />
   <Property Name="DynamicBeforeAssembleFinalizeMacros" Value="" />
   <Property Name="DynamicBeforeCompileMacros" Value="" />
+  <Property Name="StripDebugFlags" Value="" />
+  <Property Name="StripDebugFlags" Value="-NoPDB -NoDebugInfo" If="'$(StripDebugSymbols)' == 'true'" />
 
   <!-- 
     Include all the macros dynamically defined by UET.
@@ -84,6 +84,27 @@
   -->
   <Macro Name="RemoveStalePrecompiledHeaders" Arguments="ProjectPath;TargetName;TargetPlatform;TargetConfiguration">
     <Spawn Exe="$(UETPath)" Arguments="$(UETGlobalArgs) internal remove-stale-precompiled-headers --engine-path &quot;$(EnginePath)&quot; --project-path &quot;$(ProjectPath)&quot; --target-name &quot;$(TargetName)&quot; --target-platform &quot;$(TargetPlatform)&quot; --target-configuration &quot;$(TargetConfiguration)&quot;" />
+  </Macro>
+
+  <!--
+    Strip debugging symbols out of the target platform's binaries if requested.
+  -->
+  <Macro Name="StripDebugSymbolsForTarget" Arguments="PluginPath;TargetPlatform;FilesTag">
+    <Switch>
+      <Case If="'$(TargetPlatform)' == 'Win64'">
+        <Tag BaseDir="$(PluginPath)" Files="$(FilesTag)" Filter="*.pdb" With="$(FilesTag)_Debug" />
+      </Case>
+      <Case If="'$(TargetPlatform)' == 'Mac' or '$(TargetPlatform)' == 'IOS' or '$(TargetPlatform)' == 'TVOS'">
+        <Tag BaseDir="$(PluginPath)" Files="$(FilesTag)" Filter="*.a" With="$(FilesTag)_Debug" />
+      </Case>
+      <Case If="'$(TargetPlatform)' == 'Android' or '$(TargetPlatform)' == 'GooglePlay' or '$(TargetPlatform)' == 'MetaQuest'">
+        <Tag BaseDir="$(PluginPath)" Files="$(FilesTag)" Filter="*.a;*.so" With="$(FilesTag)_Debug" />
+      </Case>
+      <Case If="'$(TargetPlatform)' == 'Linux'">
+        <Tag BaseDir="$(PluginPath)" Files="$(FilesTag)" Filter="*" With="$(FilesTag)_Debug" />
+      </Case>
+    </Switch>
+    <Strip BaseDir="$(PluginPath)" OutputDir="$(PluginPath)" Platform="$(TargetPlatform)" Files="$(FilesTag)_Debug" If="'$(StripDebugSymbols)' == 'true'" />
   </Macro>
 
   <!--
@@ -369,7 +390,19 @@ $(PackageExclude);
         <Expand Name="$(MacroName)" TargetType="Editor" TargetName="$(EnginePrefix)Editor" TargetPlatform="Mac" TargetConfiguration="Development" HostPlatform="Mac" />
       </ForEach>
       <Expand Name="RemoveStalePrecompiledHeaders" ProjectPath="$(TempPath)/$(HostProjectName)" TargetName="$(EnginePrefix)Editor" TargetPlatform="Mac" TargetConfiguration="Development" />
-      <Compile Target="$(EnginePrefix)Editor" Platform="Mac" Configuration="Development" Tag="#EditorBinaries_Mac" Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; -NoPDB -NoDebugInfo $(AdditionalArguments)"/>
+      <Compile
+        Target="$(EnginePrefix)Editor"
+        Platform="Mac"
+        Configuration="Development"
+        Tag="#EditorBinaries_Mac"
+        Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(StripDebugFlags) $(AdditionalArguments)"
+      />
+      <Expand
+        Name="StripDebugSymbolsForTarget"
+        PluginPath="$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)"
+        TargetPlatform="Mac"
+        FilesTag="#EditorBinaries_Mac"
+      />
     </Node>
     <Property Name="EditorBinaries" Value="$(EditorBinaries)#EditorBinaries_Mac;" If="'$(PackageType)' == 'Generic' and '$(CanBuildEditorMac)' == 'true'" />
     <Property Name="BuildTasks" Value="$(BuildTasks)Compile $(EnginePrefix)Editor Mac;" If="'$(CanBuildEditorMac)' == 'true'" />
@@ -381,7 +414,19 @@ $(PackageExclude);
         <Expand Name="$(MacroName)" TargetType="Editor" TargetName="$(EnginePrefix)Editor" TargetPlatform="Win64" TargetConfiguration="Development" HostPlatform="Win64" />
       </ForEach>
       <Expand Name="RemoveStalePrecompiledHeaders" ProjectPath="$(TempPath)/$(HostProjectName)" TargetName="$(EnginePrefix)Editor" TargetPlatform="Win64" TargetConfiguration="Development" />
-      <Compile Target="$(EnginePrefix)Editor" Platform="Win64" Configuration="Development" Tag="#EditorBinaries_Win64" Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(2017Flag) $(AdditionalArguments)"/>
+      <Compile
+        Target="$(EnginePrefix)Editor"
+        Platform="Win64"
+        Configuration="Development"
+        Tag="#EditorBinaries_Win64"
+        Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(StripDebugFlags) $(AdditionalArguments)"
+      />
+      <Expand
+        Name="StripDebugSymbolsForTarget"
+        PluginPath="$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)"
+        TargetPlatform="Win64"
+        FilesTag="#EditorBinaries_Win64"
+      />
     </Node>
     <Property Name="EditorBinaries" Value="$(EditorBinaries)#EditorBinaries_Win64;" If="'$(PackageType)' == 'Generic' and '$(CanBuildEditorWin64)' == 'true'" />
     <Property Name="BuildTasks" Value="$(BuildTasks)Compile $(EnginePrefix)Editor Win64;" If="'$(CanBuildEditorWin64)' == 'true'" />
@@ -435,7 +480,13 @@ $(PackageExclude);
               Platform="$(TargetPlatform)"
               Configuration="$(TargetConfiguration)"
               Tag="#GameBinaries_$(TargetName)_$(TargetPlatform)_$(TargetConfiguration)_WithIntermediate"
-              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; -NoPDB -NoDebugInfo $(AdditionalArguments)"
+              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(StripDebugFlags) $(AdditionalArguments)"
+            />
+            <Expand
+              Name="StripDebugSymbolsForTarget"
+              PluginPath="$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)"
+              TargetPlatform="$(TargetPlatform)"
+              FilesTag="#GameBinaries_$(TargetName)_$(TargetPlatform)_$(TargetConfiguration)_WithIntermediate"
             />
             <Property Name="BinaryExceptRule" Value="" />
             <Property Name="BinaryExceptRule" Value=".../Intermediate/.../Inc/..." If="'$(TargetConfiguration)' != 'Shipping'" />
@@ -484,7 +535,13 @@ $(PackageExclude);
               Platform="$(TargetPlatform)"
               Configuration="$(TargetConfiguration)"
               Tag="#GameBinaries_$(TargetName)_$(TargetPlatform)_$(TargetConfiguration)_WithIntermediate"
-              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(2017Flag) $(AdditionalArguments)"
+              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(StripDebugFlags) $(AdditionalArguments)"
+            />
+            <Expand
+              Name="StripDebugSymbolsForTarget"
+              PluginPath="$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)"
+              TargetPlatform="$(TargetPlatform)"
+              FilesTag="#GameBinaries_$(TargetName)_$(TargetPlatform)_$(TargetConfiguration)_WithIntermediate"
             />
             <Property Name="BinaryExceptRule" Value="" />
             <Property Name="BinaryExceptRule" Value=".../Intermediate/.../Inc/..." If="'$(TargetConfiguration)' != 'Shipping'" />
@@ -539,7 +596,7 @@ $(PackageExclude);
               Target="$(TargetName)"
               Platform="$(TargetPlatform)"
               Configuration="$(TargetConfiguration)"
-              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(2017Flag) $(AdditionalArguments)"
+              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(StripDebugFlags) $(AdditionalArguments)"
             />
           </Node>
           <Property Name="BuildTasks" Value="$(BuildTasks)Compile $(TargetName) $(TargetPlatform) $(TargetConfiguration);" If="!ContainsItem('$(MacPlatforms)', '$(TargetPlatform)', ';')" />
@@ -578,7 +635,7 @@ $(PackageExclude);
               Target="$(TargetName)"
               Platform="$(TargetPlatform)"
               Configuration="$(TargetConfiguration)"
-              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(2017Flag) $(AdditionalArguments)"
+              Arguments="-Project=&quot;$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject&quot; -plugin=&quot;$(TempPath)/$(HostProjectName)/Plugins/$(ShortPluginName)/$(PluginName).uplugin&quot; $(StripDebugFlags) $(AdditionalArguments)"
             />
           </Node>
           <Property Name="BuildTasks" Value="$(BuildTasks)Compile $(TargetName) $(TargetPlatform) $(TargetConfiguration);" If="!ContainsItem('$(MacPlatforms)', '$(TargetPlatform)', ';')" />

--- a/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPluginBuild.cs
+++ b/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPluginBuild.cs
@@ -33,5 +33,11 @@
         /// </summary>
         [JsonPropertyName("StrictIncludes"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? StrictIncludes { get; set; }
+
+        /// <summary>
+        /// If enabled, debug symbols and PDBs will be omitted, even for non-Shipping configurations.
+        /// </summary>
+        [JsonPropertyName("StripDebugSymbols"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? StripDebugSymbols { get; set; }
     }
 }

--- a/UET/Redpoint.Uet.SdkManagement/Sdk/WindowsSdkSetup.cs
+++ b/UET/Redpoint.Uet.SdkManagement/Sdk/WindowsSdkSetup.cs
@@ -31,7 +31,7 @@
         public async Task<string> ComputeSdkPackageId(string unrealEnginePath, CancellationToken cancellationToken)
         {
             var versions = await _versionNumberResolver.For<IWindowsVersionNumbers>(unrealEnginePath).GetWindowsVersionNumbersAsync(unrealEnginePath).ConfigureAwait(false);
-            return $"{versions.WindowsSdkPreferredVersion}-{versions.VisualCppMinimumVersion}-v2";
+            return $"{versions.WindowsSdkPreferredVersion}-{versions.VisualCppMinimumVersion}-v3";
         }
 
         public async Task GenerateSdkPackage(string unrealEnginePath, string sdkPackagePath, CancellationToken cancellationToken)

--- a/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
@@ -511,15 +511,15 @@
                 BuildGraphSettings = new Dictionary<string, string>
                 {
                     // Environment options
-                    { $"UETPath", $"__UET_PATH__" },
+                    { "UETPath", $"__UET_PATH__" },
                     { "UETGlobalArgs", _globalArgsProvider?.GlobalArgsString ?? string.Empty },
                     { "EnginePath", "__ENGINE_PATH__" },
-                    { $"TempPath", $"__REPOSITORY_ROOT__/.uet/tmp" },
-                    { $"ProjectRoot", $"__REPOSITORY_ROOT__" },
-                    { $"PluginDirectory", isPluginRooted ? $"__REPOSITORY_ROOT__" : $"__REPOSITORY_ROOT__/{pluginInfo.PluginName}" },
-                    { $"PluginName", pluginInfo.PluginName },
-                    { $"Distribution", distribution.Name },
-                    { $"ArtifactExportPath", "__ARTIFACT_EXPORT_PATH__" },
+                    { "TempPath", $"__REPOSITORY_ROOT__/.uet/tmp" },
+                    { "ProjectRoot", $"__REPOSITORY_ROOT__" },
+                    { "PluginDirectory", isPluginRooted ? $"__REPOSITORY_ROOT__" : $"__REPOSITORY_ROOT__/{pluginInfo.PluginName}" },
+                    { "PluginName", pluginInfo.PluginName },
+                    { "Distribution", distribution.Name },
+                    { "ArtifactExportPath", "__ARTIFACT_EXPORT_PATH__" },
 
                     // Dynamic graph
                     { "ScriptNodeIncludes", scriptNodeIncludes },
@@ -529,21 +529,21 @@
                     { "IsUnrealEngine5", "true" },
 
                     // Clean options
-                    { $"CleanDirectories", string.Join(";", cleanDirectories) },
+                    { "CleanDirectories", string.Join(";", cleanDirectories) },
 
                     // Build options
-                    { $"ExecuteBuild", executeBuild ? "true" : "false" },
-                    { $"EditorTargetPlatforms", string.Join(";", editorTargetPlatforms) },
-                    { $"GameTargetPlatforms", gameConfig.TargetPlatforms },
-                    { $"ClientTargetPlatforms", clientConfig.TargetPlatforms },
-                    { $"ServerTargetPlatforms", serverConfig.TargetPlatforms },
-                    { $"GameConfigurations", gameConfig.Configurations },
-                    { $"ClientConfigurations", clientConfig.Configurations },
-                    { $"ServerConfigurations", serverConfig.Configurations },
-                    { $"MacPlatforms", $"IOS;Mac" },
-                    { $"StrictIncludes", strictIncludes || strictIncludesAtPluginLevel ? "true" : "false" },
-                    { $"Allow2019", "false" },
-                    { $"EnginePrefix", "Unreal" },
+                    { "ExecuteBuild", executeBuild ? "true" : "false" },
+                    { "EditorTargetPlatforms", string.Join(";", editorTargetPlatforms) },
+                    { "GameTargetPlatforms", gameConfig.TargetPlatforms },
+                    { "ClientTargetPlatforms", clientConfig.TargetPlatforms },
+                    { "ServerTargetPlatforms", serverConfig.TargetPlatforms },
+                    { "GameConfigurations", gameConfig.Configurations },
+                    { "ClientConfigurations", clientConfig.Configurations },
+                    { "ServerConfigurations", serverConfig.Configurations },
+                    { "MacPlatforms", $"IOS;Mac" },
+                    { "StrictIncludes", strictIncludes || strictIncludesAtPluginLevel ? "true" : "false" },
+                    { "EnginePrefix", "Unreal" },
+                    { "StripDebugSymbols", (distribution.Build?.StripDebugSymbols ?? false) ? "true" : "false" },
 
                     // Package options
                     { "VersionNumber", versionInfo.versionNumber },
@@ -624,24 +624,24 @@
                     { "Timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) },
 
                     // Build options
-                    { $"ExecuteBuild", executeBuild ? "true" : "false" },
-                    { $"EditorTarget", editorTarget },
-                    { $"GameTargets", gameConfig.Targets },
-                    { $"ClientTargets", clientConfig.Targets },
-                    { $"ServerTargets", serverConfig.Targets },
-                    { $"GameTargetPlatforms", gameConfig.TargetPlatforms },
-                    { $"ClientTargetPlatforms", clientConfig.TargetPlatforms },
-                    { $"ServerTargetPlatforms", serverConfig.TargetPlatforms },
-                    { $"GameConfigurations", gameConfig.Configurations },
-                    { $"ClientConfigurations", clientConfig.Configurations },
-                    { $"ServerConfigurations", serverConfig.Configurations },
-                    { $"AndroidGameCookFlavors", gameConfig.CookFlavors },
-                    { $"AndroidClientCookFlavors", clientConfig.CookFlavors },
-                    { $"MacPlatforms", $"IOS;Mac" },
-                    { $"StrictIncludes", strictIncludes ? "true" : "false" },
+                    { "ExecuteBuild", executeBuild ? "true" : "false" },
+                    { "EditorTarget", editorTarget },
+                    { "GameTargets", gameConfig.Targets },
+                    { "ClientTargets", clientConfig.Targets },
+                    { "ServerTargets", serverConfig.Targets },
+                    { "GameTargetPlatforms", gameConfig.TargetPlatforms },
+                    { "ClientTargetPlatforms", clientConfig.TargetPlatforms },
+                    { "ServerTargetPlatforms", serverConfig.TargetPlatforms },
+                    { "GameConfigurations", gameConfig.Configurations },
+                    { "ClientConfigurations", clientConfig.Configurations },
+                    { "ServerConfigurations", serverConfig.Configurations },
+                    { "AndroidGameCookFlavors", gameConfig.CookFlavors },
+                    { "AndroidClientCookFlavors", clientConfig.CookFlavors },
+                    { "MacPlatforms", $"IOS;Mac" },
+                    { "StrictIncludes", strictIncludes ? "true" : "false" },
 
                     // Stage options
-                    { $"StageDirectory", string.IsNullOrWhiteSpace(alternateStagingDirectory) ? $"__REPOSITORY_ROOT__/{distribution.FolderName}/Saved/StagedBuilds" : alternateStagingDirectory.Replace("__REPOSITORY_ROOT__", $"__REPOSITORY_ROOT__/{distribution.FolderName}", StringComparison.Ordinal) },
+                    { "StageDirectory", string.IsNullOrWhiteSpace(alternateStagingDirectory) ? $"__REPOSITORY_ROOT__/{distribution.FolderName}/Saved/StagedBuilds" : alternateStagingDirectory.Replace("__REPOSITORY_ROOT__", $"__REPOSITORY_ROOT__/{distribution.FolderName}", StringComparison.Ordinal) },
 
                     // Version options
                     { "ReleaseVersion", releaseVersion },
@@ -722,16 +722,16 @@
                 BuildGraphSettings = new Dictionary<string, string>
                 {
                     // Environment options
-                    { $"UETPath", $"__UET_PATH__" },
+                    { "UETPath", $"__UET_PATH__" },
                     { "UETGlobalArgs", _globalArgsProvider?.GlobalArgsString ?? string.Empty },
                     { "EnginePath", "__ENGINE_PATH__" },
-                    { $"TempPath", $"__REPOSITORY_ROOT__/.uet/tmp" },
-                    { $"ProjectRoot", $"__REPOSITORY_ROOT__" },
-                    { $"PluginDirectory", $"__REPOSITORY_ROOT__" },
-                    { $"PluginName", Path.GetFileNameWithoutExtension(pathSpec.UPluginPath)! },
+                    { "TempPath", $"__REPOSITORY_ROOT__/.uet/tmp" },
+                    { "ProjectRoot", $"__REPOSITORY_ROOT__" },
+                    { "PluginDirectory", $"__REPOSITORY_ROOT__" },
+                    { "PluginName", Path.GetFileNameWithoutExtension(pathSpec.UPluginPath)! },
                     // @note: This is only used for naming the package ZIPs now.
-                    { $"Distribution", packageType.ToString() },
-                    { $"ArtifactExportPath", "__ARTIFACT_EXPORT_PATH__" },
+                    { "Distribution", packageType.ToString() },
+                    { "ArtifactExportPath", "__ARTIFACT_EXPORT_PATH__" },
 
                     // Dynamic graph
                     { "ScriptIncludes", string.Empty },
@@ -740,17 +740,17 @@
                     { "IsUnrealEngine5", "true" },
 
                     // Clean options
-                    { $"CleanDirectories", string.Empty },
+                    { "CleanDirectories", string.Empty },
 
                     // Build options
-                    { $"ExecuteBuild", "true" },
-                    { $"EditorTargetPlatforms", targetPlatform },
-                    { $"GameTargetPlatforms", string.Join(";", new[] { targetPlatform }.Concat(extraPlatforms)) },
-                    { $"GameConfigurations", gameConfigurations },
-                    { $"MacPlatforms", $"IOS;Mac" },
-                    { $"StrictIncludes", strictIncludes ? "true" : "false" },
-                    { $"Allow2019", "false" },
-                    { $"EnginePrefix", "Unreal" },
+                    { "ExecuteBuild", "true" },
+                    { "EditorTargetPlatforms", targetPlatform },
+                    { "GameTargetPlatforms", string.Join(";", new[] { targetPlatform }.Concat(extraPlatforms)) },
+                    { "GameConfigurations", gameConfigurations },
+                    { "MacPlatforms", $"IOS;Mac" },
+                    { "StrictIncludes", strictIncludes ? "true" : "false" },
+                    { "EnginePrefix", "Unreal" },
+                    { "StripDebugSymbols", "false" },
 
                     // Package options
                     { "VersionNumber", versionInfo.versionNumber },
@@ -815,41 +815,41 @@
                 BuildGraphSettings = new Dictionary<string, string>
                 {
                     // Environment options
-                    { $"UETPath", $"__UET_PATH__" },
+                    { "UETPath", $"__UET_PATH__" },
                     { "EnginePath", "__ENGINE_PATH__" },
-                    { $"TempPath", $"__REPOSITORY_ROOT__/.uet/tmp" },
-                    { $"ProjectRoot", $"__REPOSITORY_ROOT__" },
-                    { $"RepositoryRoot", $"__REPOSITORY_ROOT__" },
-                    { $"ArtifactExportPath", "__ARTIFACT_EXPORT_PATH__" },
+                    { "TempPath", $"__REPOSITORY_ROOT__/.uet/tmp" },
+                    { "ProjectRoot", $"__REPOSITORY_ROOT__" },
+                    { "RepositoryRoot", $"__REPOSITORY_ROOT__" },
+                    { "ArtifactExportPath", "__ARTIFACT_EXPORT_PATH__" },
 
                     // Dynamic graph
                     { "ScriptIncludes", string.Empty },
 
                     // General options
-                    { $"UProjectPath", $"__REPOSITORY_ROOT__/{Path.GetFileName(pathSpec.UProjectPath)}" },
-                    { $"Distribution", "None" },
+                    { "UProjectPath", $"__REPOSITORY_ROOT__/{Path.GetFileName(pathSpec.UProjectPath)}" },
+                    { "Distribution", "None" },
                     { "IsUnrealEngine5", "true" },
                     { "Timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) },
 
                     // Build options
-                    { $"ExecuteBuild", "true" },
-                    { $"EditorTarget", editorTarget },
-                    { $"GameTargets", gameTarget },
-                    { $"ClientTargets", string.Empty },
-                    { $"ServerTargets", string.Empty },
-                    { $"GameTargetPlatforms", string.Join(";", new[] { gameTargetPlatform }.Concat(extraPlatforms)) },
-                    { $"ClientTargetPlatforms", string.Empty },
-                    { $"ServerTargetPlatforms", string.Empty },
-                    { $"GameConfigurations", gameConfigurations },
-                    { $"ClientConfigurations", string.Empty },
-                    { $"ServerConfigurations", string.Empty },
-                    { $"AndroidGameCookFlavors", string.Empty },
-                    { $"AndroidClientCookFlavors", string.Empty },
-                    { $"MacPlatforms", $"IOS;Mac" },
-                    { $"StrictIncludes", strictIncludes ? "true" : "false" },
+                    { "ExecuteBuild", "true" },
+                    { "EditorTarget", editorTarget },
+                    { "GameTargets", gameTarget },
+                    { "ClientTargets", string.Empty },
+                    { "ServerTargets", string.Empty },
+                    { "GameTargetPlatforms", string.Join(";", new[] { gameTargetPlatform }.Concat(extraPlatforms)) },
+                    { "ClientTargetPlatforms", string.Empty },
+                    { "ServerTargetPlatforms", string.Empty },
+                    { "GameConfigurations", gameConfigurations },
+                    { "ClientConfigurations", string.Empty },
+                    { "ServerConfigurations", string.Empty },
+                    { "AndroidGameCookFlavors", string.Empty },
+                    { "AndroidClientCookFlavors", string.Empty },
+                    { "MacPlatforms", $"IOS;Mac" },
+                    { "StrictIncludes", strictIncludes ? "true" : "false" },
 
                     // Stage options
-                    { $"StageDirectory", string.IsNullOrWhiteSpace(alternateStagingDirectory) ? $"__REPOSITORY_ROOT__/Saved/StagedBuilds" : alternateStagingDirectory },
+                    { "StageDirectory", string.IsNullOrWhiteSpace(alternateStagingDirectory) ? $"__REPOSITORY_ROOT__/Saved/StagedBuilds" : alternateStagingDirectory },
 
                     // Version options
                     { "ReleaseVersion", releaseVersion },


### PR DESCRIPTION
This also updates the Windows SDK installation to download and install PDBCopy automatically, which is necessary for symbol removal.