### PR TITLE
Support BuildConfig.json in the same directory as an engine for engine builds

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Executors.BuildServer/BuildJobJson.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Executors.BuildServer/BuildJobJson.cs
@@ -12,12 +12,6 @@
         [JsonPropertyName("Engine"), JsonRequired]
         public string Engine { get; set; } = string.Empty;
 
-        /// <summary>
-        /// If true, the engine itself is being built, rather than building a project or plugin with the engine.
-        /// </summary>
-        [JsonPropertyName("IsEngineBuild"), JsonRequired]
-        public bool IsEngineBuild { get; set; } = false;
-
         [JsonPropertyName("SharedStoragePath"), JsonRequired]
         public string SharedStoragePath { get; set; } = string.Empty;
 

--- a/UET/Redpoint.Uet.BuildPipeline.Executors.BuildServer/BuildServerBuildExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Executors.BuildServer/BuildServerBuildExecutor.cs
@@ -655,7 +655,6 @@
                 var buildJobJson = new BuildJobJson
                 {
                     Engine = buildSpecification.Engine.ToReparsableString(),
-                    IsEngineBuild = buildSpecification.Engine.IsEngineBuild,
                     SharedStoragePath = job.Agent.Platform switch
                     {
                         BuildServerJobPlatform.Windows => buildSpecification.BuildGraphEnvironment.Windows.SharedStorageAbsolutePath,

--- a/UET/Redpoint.Uet.BuildPipeline/Executors/BuildEngineSpecification.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/Executors/BuildEngineSpecification.cs
@@ -2,6 +2,15 @@
 {
     using System.Diagnostics.CodeAnalysis;
 
+    public enum BuildEngineSpecificationEngineBuildType
+    {
+        None,
+
+        ExternalSource,
+
+        CurrentWorkspace,
+    }
+
     public class BuildEngineSpecification
     {
         internal string? _engineVersion { get; private set; }
@@ -14,7 +23,8 @@
         internal string? _gitSharedMacCachePath { get; private set; }
         internal string? _sesNetworkShare { get; private set; }
         internal string? _remoteZfs { get; private set; }
-        public bool IsEngineBuild { get; private set; } = false;
+        internal bool _currentWorkspace { get; private set; }
+        public BuildEngineSpecificationEngineBuildType EngineBuildType { get; private set; } = BuildEngineSpecificationEngineBuildType.None;
 
         public static BuildEngineSpecification ForVersionWithPath(string version, string localPath)
         {
@@ -73,7 +83,18 @@
                 _gitConsoleZips = uefsGitConsoleZips ?? Array.Empty<string>(),
                 _gitSharedWindowsCachePath = windowsSharedGitCachePath,
                 _gitSharedMacCachePath = macSharedGitCachePath,
-                IsEngineBuild = isEngineBuild,
+                EngineBuildType = isEngineBuild
+                    ? BuildEngineSpecificationEngineBuildType.ExternalSource
+                    : BuildEngineSpecificationEngineBuildType.None,
+            };
+        }
+
+        public static BuildEngineSpecification ForEngineInCurrentWorkspace()
+        {
+            return new BuildEngineSpecification
+            {
+                _currentWorkspace = true,
+                EngineBuildType = BuildEngineSpecificationEngineBuildType.CurrentWorkspace,
             };
         }
 
@@ -82,7 +103,11 @@
         /// </remarks>
         public string ToReparsableString()
         {
-            if (!string.IsNullOrWhiteSpace(_uefsPackageTag))
+            if (_currentWorkspace)
+            {
+                return $"self:true";
+            }
+            else if (!string.IsNullOrWhiteSpace(_uefsPackageTag))
             {
                 return $"uefs:{_uefsPackageTag}";
             }

--- a/UET/Redpoint.Uet.BuildPipeline/Executors/Engine/DefaultEngineWorkspaceProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/Executors/Engine/DefaultEngineWorkspaceProvider.cs
@@ -68,7 +68,9 @@
                         AdditionalFolderZips = buildEngineSpecification._gitConsoleZips!,
                         WorkspaceDisambiguators = new[] { workspaceSuffix },
                         ProjectFolderName = null,
-                        BuildType = buildEngineSpecification.IsEngineBuild ? GitWorkspaceDescriptorBuildType.Engine : GitWorkspaceDescriptorBuildType.Generic,
+                        BuildType = buildEngineSpecification.EngineBuildType != BuildEngineSpecificationEngineBuildType.None
+                            ? GitWorkspaceDescriptorBuildType.Engine
+                            : GitWorkspaceDescriptorBuildType.Generic,
                         WindowsSharedGitCachePath = buildEngineSpecification._gitSharedWindowsCachePath,
                         MacSharedGitCachePath = buildEngineSpecification._gitSharedMacCachePath,
                     },

--- a/UET/Redpoint.Uet.Configuration/Engine/BuildConfigEngineDistribution.cs
+++ b/UET/Redpoint.Uet.Configuration/Engine/BuildConfigEngineDistribution.cs
@@ -8,8 +8,13 @@
         [JsonPropertyName("Name")]
         public string Name { get; set; } = string.Empty;
 
-        [JsonPropertyName("Source")]
-        public BuildConfigEngineSource Source { get; set; } = new BuildConfigEngineSource();
+        /// <summary>
+        /// If set, specifies that the engine source code should come from another repository. If not set, 
+        /// it is expected that the BuildConfig.json file is in the root of the engine repository, such that 
+        /// it is in the same folder that contains the "Engine" folder.
+        /// </summary>
+        [JsonPropertyName("ExternalSource")]
+        public BuildConfigEngineExternalSource? ExternalSource { get; set; }
 
         [JsonPropertyName("Build")]
         public BuildConfigEngineBuild Build { get; set; } = new BuildConfigEngineBuild();

--- a/UET/Redpoint.Uet.Configuration/Engine/BuildConfigEngineExternalSource.cs
+++ b/UET/Redpoint.Uet.Configuration/Engine/BuildConfigEngineExternalSource.cs
@@ -3,7 +3,7 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
 
-    public class BuildConfigEngineSource
+    public class BuildConfigEngineExternalSource
     {
         [JsonPropertyName("Type"), JsonRequired]
         public string Type { get; set; } = "git";

--- a/UET/Redpoint.Uet.Workspace/PhysicalGit/GitExecutionContext.cs
+++ b/UET/Redpoint.Uet.Workspace/PhysicalGit/GitExecutionContext.cs
@@ -8,7 +8,6 @@
         public required string Git { get; init; }
         public required IReadOnlyDictionary<string, string> GitEnvs { get; init; }
         public required Func<GitTemporaryEnvVarsForFetch> FetchEnvironmentVariablesFactory { get; init; }
-        public required bool EnableSubmoduleSupport { get; init; }
-        public required bool EnableLfsSupport { get; init; }
+        public required bool EnableSubmoduleSupport { get; set; }
     }
 }

--- a/UET/uet/Commands/ParameterSpec/EngineSpecType.cs
+++ b/UET/uet/Commands/ParameterSpec/EngineSpecType.cs
@@ -14,12 +14,17 @@
         /// The engine itself is being built. This can never be returned by <see cref="EngineSpec.TryParseEngineSpecExact"/>, 
         /// and is only ever returned by <see cref="EngineSpec.ParseEngineSpec(System.CommandLine.Option{PathSpec}, System.CommandLine.Option{DistributionSpec?}?)"/> when an engine distribution is supplied.
         /// 
-        /// Commands like <c>ci-build</c> will always receive a value like <see cref="GitCommit"/> instead.
+        /// Commands like <c>ci-build</c> will always receive a value like <see cref="GitCommit"/> or <see cref="CurrentWorkspace"/> instead.
         /// </summary>
         SelfEngineByBuildConfig,
 
         SESNetworkShare,
 
         RemoteZfs,
+
+        /// <summary>
+        /// The engine is in the same workspace as the "project" (i.e. the engine is what is being built). This is the engine spec type when an engine is being built without an external source repository specified.
+        /// </summary>
+        CurrentWorkspace,
     }
 }


### PR DESCRIPTION
The "Source" property of engine distributions has been renamed to "ExternalSource", and you can now place a BuildConfig.json file in the repository root containing an engine to do an installed engine build.