### PR TITLE
Allow turning off Intel plugin builds for macOS

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
@@ -73,6 +73,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"StrictIncludes", $"false" },
                     { $"StageDirectory", $"__REPOSITORY_ROOT__/Saved/StagedBuilds" },
                     { "StripDebugSymbols", "false" },
+                    { "AppleArchitectureOnly", "false" },
                 },
                 new Dictionary<string, string>
                 {
@@ -141,6 +142,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"CopyrightHeader", $"" },
                     { $"CopyrightExcludes", $"" },
                     { "StripDebugSymbols", "false" },
+                    { "AppleArchitectureOnly", "false" },
                 },
                 new Dictionary<string, string>
                 {

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
@@ -31,6 +31,7 @@
   <Option Name="EnginePrefix" Restrict="UE4|Unreal" DefaultValue="UE4" Description="Prefix of the engine targets (UE5 has a different prefix)" />
   <Option Name="ExecuteBuild" Restrict="true|false" DefaultValue="true" Description="If false, no build steps are run (currently ignored)" />
   <Option Name="StripDebugSymbols" Restrict="true|false" DefaultValue="false" Description="If true, debugging symbols are stripped and not present" />
+  <Option Name="AppleArchitectureOnly" Restrict="true|false" DefaultValue="false" Description="If true, for Mac the plugin will only be built for Apple ARM64 architectures (and not legacy Intel x64)" />
 
   <!-- Package options -->
   <Option Name="VersionNumber" Restrict="[0-9]+" DefaultValue="10000" Description="The version number to embed in the packaged .uplugin file" />
@@ -325,9 +326,19 @@ $(PackageExclude);
         File="$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject"
         Text="{ &quot;FileVersion&quot;: 3, &quot;Plugins&quot;: [ { &quot;Name&quot;: &quot;$(PluginName)&quot;, &quot;Enabled&quot;: true } ] }"
       />
+      <WriteTextFile
+        File="$(TempPath)/$(HostProjectName)/Config/Mac/MacEngine.ini"
+        Text="[/Script/MacTargetPlatform.MacTargetSettings]&#xA;TargetArchitecture=apple&#xA;DefaultArchitecture=apple&#xA;EditorTargetArchitecture=apple&#xA;EditorDefaultArchitecture=apple&#xA;bBuildAllSupportedOnBuildMachine=False"
+        If="'$(AppleArchitectureOnly)' == 'true'"
+      />
       <Tag
         Files="$(TempPath)/$(HostProjectName)/$(HostProjectName).uproject"
         With="#HostProject"
+      />
+      <Tag
+        Files="$(TempPath)/$(HostProjectName)/Config/Mac/MacEngine.ini"
+        With="#HostProject"
+        If="'$(AppleArchitectureOnly)' == 'true'"
       />
       <Tag
         BaseDir="$(PluginDirectory)"

--- a/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPluginBuild.cs
+++ b/UET/Redpoint.Uet.Configuration/Plugin/BuildConfigPluginBuild.cs
@@ -39,5 +39,13 @@
         /// </summary>
         [JsonPropertyName("StripDebugSymbols"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? StripDebugSymbols { get; set; }
+
+        /// <summary>
+        /// If enabled, the plugin will only be built for the Apple ARM64 architecture (and not legacy 
+        /// Intel x64) when building for macOS. This can significantly reduce compilation times when you 
+        /// don't need Intel support.
+        /// </summary>
+        [JsonPropertyName("AppleArchitectureOnly"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public bool? AppleArchitectureOnly { get; set; }
     }
 }

--- a/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
@@ -544,6 +544,7 @@
                     { "StrictIncludes", strictIncludes || strictIncludesAtPluginLevel ? "true" : "false" },
                     { "EnginePrefix", "Unreal" },
                     { "StripDebugSymbols", (distribution.Build?.StripDebugSymbols ?? false) ? "true" : "false" },
+                    { "AppleArchitectureOnly", (distribution.Build?.AppleArchitectureOnly ?? false) ? "true" : "false" },
 
                     // Package options
                     { "VersionNumber", versionInfo.versionNumber },
@@ -751,6 +752,7 @@
                     { "StrictIncludes", strictIncludes ? "true" : "false" },
                     { "EnginePrefix", "Unreal" },
                     { "StripDebugSymbols", "false" },
+                    { "AppleArchitectureOnly", "false" },
 
                     // Package options
                     { "VersionNumber", versionInfo.versionNumber },


### PR DESCRIPTION
This can reduce compilation times for plugin builds when you don't need the legacy Intel architecture.