### PR TITLE
Build UnrealPak and BootstrapPackagedGame when projects are built with source engine

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
@@ -118,6 +118,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
                     { $"PluginName", $"OnlineSubsystemRedpointEOS" },
                     { $"Distribution", $"Default" },
                     { $"IsUnrealEngine5", $"true" },
+                    { $"IsUnrealEngineInstalled", $"true" },
                     { $"Timestamp", $"0" },
                     { $"CleanDirectories", $"" },
                     { $"ExecuteBuild", $"true" },

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Project.xml
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Project.xml
@@ -15,6 +15,7 @@
   <Option Name="ProjectName" Restrict=".*" DefaultValue="" Description="The name of the project being built" />
   <Option Name="Distribution" Restrict=".*" DefaultValue="" Description="The distribution being built" />
   <Option Name="IsUnrealEngine5" Restrict="true|false" DefaultValue="false" Description="If true, this is an Unreal Engine 5 project" />
+  <Option Name="IsUnrealEngineInstalled" Restrict="true|false" DefaultValue="false" Description="If true, the engine has already been turned into an 'installed build' and can't be modified." />
   <Option Name="Timestamp" Restrict="[0-9]+" DefaultValue="0" Description="The UNIX timestamp when this build was generated" />
 
   <!-- Build options -->
@@ -83,12 +84,14 @@
   -->
   <Macro Name="CompileEditor" Arguments="EditorTarget;TargetPlatform;TargetConfiguration">
     <Agent Name="Compile $(EditorTarget) $(TargetPlatform) (Windows Build)" Type="$(TargetPlatform)">
-      <Node Name="Compile $(EditorTarget) $(TargetPlatform)" Produces="#EditorBinaries">
+      <Node Name="Compile $(EditorTarget) $(TargetPlatform)" Produces="#EditorBinaries;#BuildToolBinaries">
         <ForEach Name="MacroName" Values="$(DynamicBeforeCompileMacros)">
           <Expand Name="$(MacroName)" TargetType="Editor" TargetName="$(EditorTarget)" TargetPlatform="$(TargetPlatform)" TargetConfiguration="$(TargetConfiguration)" HostPlatform="$(TargetPlatform)" />
         </ForEach>
         <Expand Name="RemoveStalePrecompiledHeaders" ProjectPath="$(ProjectRoot)" TargetName="$(EditorTarget)" TargetPlatform="$(TargetPlatform)" TargetConfiguration="$(TargetConfiguration)" />
         <Compile Target="$(EditorTarget)" Platform="$(TargetPlatform)" Configuration="$(TargetConfiguration)" Tag="#EditorBinaries" Arguments="-Project=&quot;$(UProjectPath)&quot; $(AdditionalArguments)" AllowParallelExecutor="false" />
+        <Compile Target="UnrealPak" Platform="$(TargetPlatform)" Configuration="$(TargetConfiguration)" Tag="#BuildToolBinaries" Arguments="-Project=&quot;$(UProjectPath)&quot; $(AdditionalArguments)" AllowParallelExecutor="false" If="'$(IsUnrealEngineInstalled)' != 'true'" />
+        <Compile Target="BootstrapPackagedGame" Platform="$(TargetPlatform)" Configuration="$(TargetConfiguration)" Tag="#BuildToolBinaries" Arguments="-Project=&quot;$(UProjectPath)&quot; $(AdditionalArguments)" AllowParallelExecutor="false" If="'$(IsUnrealEngineInstalled)' != 'true'" />
       </Node>
     </Agent>
   </Macro>
@@ -216,7 +219,7 @@
       <Property Name="StageOutputs" Value="$(StageOutputs)_$(CookFlavor)" If="'$(CookFlavor)' != 'NoCookFlavor'" />
 
       <!-- Specify the job to run. We do all our other property declarations under here due to BuildGraph quirks. -->
-      <Node Name="Pak and Stage $(TargetName) $(TargetStore) $(TargetConfiguration) $(CookFlavor)" Requires="#$(TargetType)Binaries_$(TargetName)_$(TargetPlatform)_$(TargetConfiguration);#$(TargetType)CookedContent_$(TargetPlatform)_$(CookFlavor)" Produces="$(StageOutputs)">
+      <Node Name="Pak and Stage $(TargetName) $(TargetStore) $(TargetConfiguration) $(CookFlavor)" Requires="#$(TargetType)Binaries_$(TargetName)_$(TargetPlatform)_$(TargetConfiguration);#$(TargetType)CookedContent_$(TargetPlatform)_$(CookFlavor);#BuildToolBinaries" Produces="$(StageOutputs)">
 
         <!-- Configure directory seperator based on host platform. -->
         <Property Name="Slash" Value="\" />

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/DefaultBuildGraphArgumentGenerator.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/DefaultBuildGraphArgumentGenerator.cs
@@ -20,6 +20,10 @@
                 value = value.Replace("__REPOSITORY_ROOT__", repositoryRoot, StringComparison.Ordinal);
                 value = value.Replace("__UET_PATH__", uetPath, StringComparison.Ordinal);
                 value = value.Replace("__ENGINE_PATH__", enginePath.TrimEnd('\\'), StringComparison.Ordinal);
+                value = value.Replace(
+                    "__UNREAL_ENGINE_IS_INSTALLED_BUILD__",
+                    File.Exists(Path.Combine(enginePath, "Engine", "Build", "InstalledBuild.txt")) ? "true" : "false",
+                    StringComparison.Ordinal);
                 value = value.Replace("__SHARED_STORAGE_PATH__", sharedStoragePath, StringComparison.Ordinal);
                 value = value.Replace("__ARTIFACT_EXPORT_PATH__", artifactExportPath, StringComparison.Ordinal);
                 foreach (var sr in replacements)
@@ -47,6 +51,10 @@
                 value = value.Replace("__REPOSITORY_ROOT__", repositoryRoot, StringComparison.Ordinal);
                 value = value.Replace("__UET_PATH__", uetPath, StringComparison.Ordinal);
                 value = value.Replace("__ENGINE_PATH__", enginePath.TrimEnd('\\'), StringComparison.Ordinal);
+                value = value.Replace(
+                    "__UNREAL_ENGINE_IS_INSTALLED_BUILD__",
+                    File.Exists(Path.Combine(enginePath, "Engine", "Build", "InstalledBuild.txt")) ? "true" : "false",
+                    StringComparison.Ordinal);
                 value = value.Replace("__SHARED_STORAGE_PATH__", sharedStoragePath, StringComparison.Ordinal);
                 value = value.Replace("__ARTIFACT_EXPORT_PATH__", artifactExportPath, StringComparison.Ordinal);
                 foreach (var sr in replacements)

--- a/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
+++ b/UET/uet/Commands/Build/DefaultBuildSpecificationGenerator.cs
@@ -622,6 +622,7 @@
                     { "ProjectName", distribution.ProjectName },
                     { "Distribution", distribution.Name },
                     { "IsUnrealEngine5", "true" },
+                    { "IsUnrealEngineInstalled", "__UNREAL_ENGINE_IS_INSTALLED_BUILD__" },
                     { "Timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) },
 
                     // Build options
@@ -831,6 +832,7 @@
                     { "UProjectPath", $"__REPOSITORY_ROOT__/{Path.GetFileName(pathSpec.UProjectPath)}" },
                     { "Distribution", "None" },
                     { "IsUnrealEngine5", "true" },
+                    { "IsUnrealEngineInstalled", "__UNREAL_ENGINE_IS_INSTALLED_BUILD__" },
                     { "Timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture) },
 
                     // Build options


### PR DESCRIPTION
This is another go at #176, this time with proper detection of whether or not the Unreal Engine being built against has already been made into an "installed build" (and thus can't have engine-level targets built).

This also builds "BootstrapPackagedGame" in addition to "UnrealPak", which should fix the missing entry point on packaged Windows builds.