### PR TITLE
Add --delete-before for rclone call

### DIFF
--- a/UET/uet/Commands/Internal/EnginePerforceToGit/EnginePerforceToGitCommand.cs
+++ b/UET/uet/Commands/Internal/EnginePerforceToGit/EnginePerforceToGitCommand.cs
@@ -669,6 +669,7 @@
                                     "sync",
                                     "--exclude=/.git/**",
                                     "--transfers=64",
+                                    "--delete-before",
                                     releaseFolder.FullName,
                                     gitWorkspacePath.FullName,
                                 ],


### PR DESCRIPTION
This should fix the "Failed to copy: open ... is a directory" error during sync.