### PR TITLE
Implement Redpoint.Windows.HostNetworkingService library

### DIFF
--- a/UET/Redpoint.Windows.HostNetworkingService.Tests/HnsTests.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService.Tests/HnsTests.cs
@@ -1,0 +1,45 @@
+﻿namespace Redpoint.Windows.HostNetworkingService.Tests
+{
+    using System.Runtime.Versioning;
+    using System.Security.Principal;
+    using Xunit;
+
+    public class HnsTests
+    {
+        private static bool IsAdministrator
+        {
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    using (var identity = WindowsIdentity.GetCurrent())
+                    {
+                        var principal = new WindowsPrincipal(identity);
+                        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+                    }
+                }
+                return false;
+            }
+        }
+
+        [Fact(Skip = "This test does not pass on the build server, but does pass locally.")]
+        [SupportedOSPlatform("windows6.2")]
+        public void CanReadHnsNetworks()
+        {
+            Skip.IfNot(OperatingSystem.IsWindowsVersionAtLeast(6, 2));
+            Skip.IfNot(IsAdministrator);
+
+            var api = IHnsApi.GetInstance();
+
+            // Just call this and check that it works.
+            try
+            {
+                _ = api.GetHnsNetworks();
+            }
+            catch (HnsNotAvailableException)
+            {
+                // This is also OK.
+            }
+        }
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService.Tests/Redpoint.Windows.HostNetworkingService.Tests.csproj
+++ b/UET/Redpoint.Windows.HostNetworkingService.Tests/Redpoint.Windows.HostNetworkingService.Tests.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/XunitTesting.Build.props" />
+
+	<ItemGroup>
+		<ProjectReference Include="..\Redpoint.Windows.HostNetworkingService\Redpoint.Windows.HostNetworkingService.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/UET/Redpoint.Windows.HostNetworkingService/ComWrapper/ClassIds.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/ComWrapper/ClassIds.cs
@@ -1,0 +1,10 @@
+﻿namespace Redpoint.Windows.HostNetworkingService.ComWrapper
+{
+    using System.Runtime.Versioning;
+
+    [SupportedOSPlatform("windows")]
+    internal static class ClassIds
+    {
+        public const string HnsApi = "C8A58877-C594-47FE-9197-BD808576F1DA";
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/ComWrapper/IHNSApi.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/ComWrapper/IHNSApi.cs
@@ -1,0 +1,69 @@
+﻿namespace Redpoint.Windows.HostNetworkingService.ComWrapper
+{
+    using System.Runtime.CompilerServices;
+    using System.Runtime.InteropServices.Marshalling;
+    using System.Runtime.InteropServices;
+    using Redpoint.Windows.HostNetworkingService;
+    using System.Runtime.Versioning;
+    using System;
+
+    [GeneratedComInterface]
+    [Guid(IID)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [SupportedOSPlatform("windows")]
+    internal partial interface IHNSApi
+    {
+        public const string IID = "0B43D888-341A-4D8C-8C3A-F9EF5045DF01";
+
+        #region IDispatch methods (unused, but necessary for vtable)
+
+        [PreserveSig]
+        int GetTypeInfoCount(out uint pctinfo);
+
+        [PreserveSig]
+        int GetTypeInfo(
+                        uint itinfo,
+                        ulong lcid,
+                        out nint pptinfo);
+
+        [PreserveSig]
+        int GetIDsOfNames(
+                        ref Guid riid,
+                        nint rgszNames,
+                        uint cNames,
+                        ulong lcid,
+                        out long rgdispid);
+
+        [PreserveSig]
+        int Invoke(
+                        long dispidMember,
+                        ref Guid riid,
+                        ulong lcid,
+                        ushort wFlags,
+                        nint pdispparams,
+                        nint pvarResult,
+                        nint pexcepinfo,
+                        nint puArgErr);
+
+        #endregion
+
+        [DispId(0x60020000)]
+        void Request([MarshalAs(UnmanagedType.LPWStr)] string Method, [MarshalAs(UnmanagedType.LPWStr)] string Path, [MarshalAs(UnmanagedType.LPWStr)] string Object, [MarshalAs(UnmanagedType.LPWStr)] out string Response);
+
+        [DispId(0x60020001)]
+        void AttachEndpoint(ref Guid EndpointId, uint CompartmentId);
+
+        [DispId(0x60020002)]
+        void DetachEndpoint(ref Guid EndpointId);
+
+        [DispId(0x60020003)]
+        void AttachEndpointVNic(ref Guid EndpointId, [MarshalAs(UnmanagedType.LPWStr)] string NicName);
+
+        [DispId(0x60020004)]
+        void GetEndpointConfiguration(ref Guid EndpointId, out uint ConfigurationDataLength, out byte EndpointConfigurationData);
+
+        [DispId(0x60020005)]
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string Request2([MarshalAs(UnmanagedType.BStr)] string Method, [MarshalAs(UnmanagedType.BStr)] string Path, [MarshalAs(UnmanagedType.BStr)] string Object);
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/ComWrapper/Ole32.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/ComWrapper/Ole32.cs
@@ -1,0 +1,59 @@
+﻿namespace Redpoint.Windows.HostNetworkingService.ComWrapper
+{
+    using System.Runtime.InteropServices.Marshalling;
+    using System.Runtime.InteropServices;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Versioning;
+
+    [SupportedOSPlatform("windows")]
+    internal static unsafe partial class Ole32
+    {
+        // https://docs.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance
+        [LibraryImport(nameof(Ole32))]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        public static partial int CoCreateInstance(
+            ref Guid rclsid,
+            nint pUnkOuter,
+            uint dwClsContext,
+            ref Guid riid,
+            // The default ComInterfaceMarshaller will unwrap a .NET object if it can tell the COM instance is a ComWrapper.
+            // This causes issues when casting to ICalculator, since the Server's Calculator class doesn't implement the Client's interface.
+            // UniqueComInterfaceMarshaller doesn't try to unwrap the object and always creates a new COM object.
+            [MarshalUsing(typeof(UniqueComInterfaceMarshaller<object>))]
+            out object ppv);
+
+        // https://learn.microsoft.com/windows/win32/api/wtypesbase/ne-wtypesbase-clsctx
+        [SuppressMessage("Naming", "CA1712:Do not prefix enum values with type name", Justification = "Enumeration value names match the C++ definitions.")]
+        public enum CLSCTX : uint
+        {
+            CLSCTX_INPROC_SERVER = 0x1,
+            CLSCTX_INPROC_HANDLER = 0x2,
+            CLSCTX_LOCAL_SERVER = 0x4,
+            CLSCTX_INPROC_SERVER16 = 0x8,
+            CLSCTX_REMOTE_SERVER = 0x10,
+            CLSCTX_INPROC_HANDLER16 = 0x20,
+            CLSCTX_RESERVED1 = 0x40,
+            CLSCTX_RESERVED2 = 0x80,
+            CLSCTX_RESERVED3 = 0x100,
+            CLSCTX_RESERVED4 = 0x200,
+            CLSCTX_NO_CODE_DOWNLOAD = 0x400,
+            CLSCTX_RESERVED5 = 0x800,
+            CLSCTX_NO_CUSTOM_MARSHAL = 0x1000,
+            CLSCTX_ENABLE_CODE_DOWNLOAD = 0x2000,
+            CLSCTX_NO_FAILURE_LOG = 0x4000,
+            CLSCTX_DISABLE_AAA = 0x8000,
+            CLSCTX_ENABLE_AAA = 0x10000,
+            CLSCTX_FROM_DEFAULT_CONTEXT = 0x20000,
+            CLSCTX_ACTIVATE_X86_SERVER = 0x40000,
+            CLSCTX_ACTIVATE_32_BIT_SERVER,
+            CLSCTX_ACTIVATE_64_BIT_SERVER = 0x80000,
+            CLSCTX_ENABLE_CLOAKING = 0x100000,
+            CLSCTX_APPCONTAINER = 0x400000,
+            CLSCTX_ACTIVATE_AAA_AS_IU = 0x800000,
+            CLSCTX_RESERVED6 = 0x1000000,
+            CLSCTX_ACTIVATE_ARM32_SERVER = 0x2000000,
+            CLSCTX_ALLOW_LOWER_TRUST_REGISTRATION,
+            CLSCTX_PS_DLL = 0x80000000,
+        }
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/DefaultHns.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/DefaultHns.cs
@@ -1,0 +1,123 @@
+﻿using Redpoint.KubernetesManager.HnsApi;
+
+namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Runtime.InteropServices.Marshalling;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Versioning;
+    using System.Text.Json;
+    using Redpoint.Windows.HostNetworkingService.ComWrapper;
+
+    [SupportedOSPlatform("windows")]
+    internal class DefaultHns : IHnsApi
+    {
+        IHNSApi? _hns;
+
+        public DefaultHns()
+        {
+            var clsid = new Guid(ClassIds.HnsApi);
+            var iid = new Guid(IHNSApi.IID);
+            int hr = Ole32.CoCreateInstance(
+                ref clsid,
+                0,
+                (uint)Ole32.CLSCTX.CLSCTX_LOCAL_SERVER,
+                ref iid,
+                out object comObject);
+            if (hr == 0)
+            {
+                _hns = (IHNSApi)comObject;
+            }
+        }
+
+        public HnsNetworkWithId[] GetHnsNetworks()
+        {
+            if (_hns == null)
+            {
+                throw new HnsNotAvailableException();
+            }
+            var responseText = _hns.Request2("GET", "/networks", "");
+            var response = JsonSerializer.Deserialize(responseText, HnsJsonSerializerContext.Default.HnsResponseHnsNetworkWithIdArray);
+            if (!(response?.Success ?? false))
+            {
+                throw new InvalidOperationException("HNS operation failed!");
+            }
+            return response?.Output ?? [];
+        }
+
+        public void NewHnsNetwork(HnsNetwork network)
+        {
+            if (_hns == null)
+            {
+                throw new HnsNotAvailableException();
+            }
+            var request = JsonSerializer.Serialize(network, HnsJsonSerializerContext.Default.HnsNetwork);
+            var response = JsonSerializer.Deserialize(
+                _hns.Request2("POST", "/networks", request),
+                HnsJsonSerializerContext.Default.HnsResponse);
+            if (!(response?.Success ?? false))
+            {
+                throw new InvalidOperationException("HNS operation failed!");
+            }
+        }
+
+        public void DeleteHnsNetwork(string id)
+        {
+            if (_hns == null)
+            {
+                throw new HnsNotAvailableException();
+            }
+            var response = JsonSerializer.Deserialize(
+                _hns.Request2("DELETE", $"/networks/{id}", ""),
+                HnsJsonSerializerContext.Default.HnsResponse);
+            if (!(response?.Success ?? false))
+            {
+                throw new InvalidOperationException("HNS operation failed!");
+            }
+        }
+
+        public HnsEndpointWithId[] GetHnsEndpoints()
+        {
+            if (_hns == null)
+            {
+                throw new HnsNotAvailableException();
+            }
+            var responseText = _hns.Request2("GET", "/endpoints", "");
+            var response = JsonSerializer.Deserialize(responseText, HnsJsonSerializerContext.Default.HnsResponseHnsEndpointWithIdArray);
+            if (!(response?.Success ?? false))
+            {
+                throw new InvalidOperationException("HNS operation failed!");
+            }
+            return response?.Output ?? [];
+        }
+
+        public HnsPolicyListWithId[] GetHnsPolicyLists()
+        {
+            if (_hns == null)
+            {
+                throw new HnsNotAvailableException();
+            }
+            var responseText = _hns.Request2("GET", "/policylists", "");
+            var response = JsonSerializer.Deserialize(responseText, HnsJsonSerializerContext.Default.HnsResponseHnsPolicyListWithIdArray);
+            if (!(response?.Success ?? false))
+            {
+                throw new InvalidOperationException("HNS operation failed!");
+            }
+            return response?.Output ?? [];
+        }
+
+        public void DeleteHnsPolicyList(string id)
+        {
+            if (_hns == null)
+            {
+                throw new HnsNotAvailableException();
+            }
+            var response = JsonSerializer.Deserialize(
+                _hns.Request2("DELETE", $"/policylists/{id}", ""),
+                HnsJsonSerializerContext.Default.HnsResponse);
+            if (!(response?.Success ?? false))
+            {
+                throw new InvalidOperationException("HNS operation failed!");
+            }
+        }
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsEndpoint.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsEndpoint.cs
@@ -1,0 +1,13 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Text.Json.Serialization;
+
+    public class HnsEndpoint
+    {
+        [JsonPropertyName("Name")]
+        public string? Name { get; set; } = null;
+
+        [JsonPropertyName("IPAddress")]
+        public string? IPAddress { get; set; } = null;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsEndpointWithId.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsEndpointWithId.cs
@@ -1,0 +1,10 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Text.Json.Serialization;
+
+    public class HnsEndpointWithId : HnsEndpoint
+    {
+        [JsonPropertyName("ID")]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsJsonSerializerContext.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsJsonSerializerContext.cs
@@ -1,0 +1,26 @@
+﻿using Redpoint.Windows.HostNetworkingService;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Redpoint.KubernetesManager.HnsApi
+{
+    [JsonSerializable(typeof(HnsEndpoint))]
+    [JsonSerializable(typeof(HnsEndpointWithId))]
+    [JsonSerializable(typeof(HnsNetwork))]
+    [JsonSerializable(typeof(HnsNetworkWithId))]
+    [JsonSerializable(typeof(HnsPolicyList))]
+    [JsonSerializable(typeof(HnsPolicyListWithId))]
+    [JsonSerializable(typeof(HnsResponse))]
+    [JsonSerializable(typeof(HnsResponse<HnsNetworkWithId[]?>))]
+    [JsonSerializable(typeof(HnsResponse<HnsEndpointWithId[]?>))]
+    [JsonSerializable(typeof(HnsResponse<HnsPolicyListWithId[]?>))]
+    [JsonSerializable(typeof(HnsSubnet))]
+    [JsonSerializable(typeof(HnsSubnetPolicy))]
+    public partial class HnsJsonSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsNetwork.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsNetwork.cs
@@ -1,0 +1,21 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json.Serialization;
+
+    public class HnsNetwork
+    {
+        [JsonPropertyName("Type")]
+        public string Type { get; set; } = string.Empty;
+
+        [JsonPropertyName("Name")]
+        public string? Name { get; set; } = null;
+
+        [JsonPropertyName("Subnets")]
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "This property is used for JSON serialization.")]
+        public HnsSubnet[] Subnets { get; set; } = Array.Empty<HnsSubnet>();
+
+        [JsonPropertyName("NetworkAdapterName")]
+        public string? NetworkAdapterName { get; set; } = null;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsNetworkWithId.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsNetworkWithId.cs
@@ -1,0 +1,10 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Text.Json.Serialization;
+
+    public class HnsNetworkWithId : HnsNetwork
+    {
+        [JsonPropertyName("ID")]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsNotAvailableException.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsNotAvailableException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Redpoint.Windows.HostNetworkingService
+{
+    public class HnsNotAvailableException : Exception
+    {
+        public HnsNotAvailableException()
+            : base("The HNS API is not available. This is likely because the Windows Containers feature is not installed.")
+        {
+        }
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsPolicyList.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsPolicyList.cs
@@ -1,0 +1,6 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    public class HnsPolicyList
+    {
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsPolicyListWithId.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsPolicyListWithId.cs
@@ -1,0 +1,10 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Text.Json.Serialization;
+
+    public class HnsPolicyListWithId : HnsPolicyList
+    {
+        [JsonPropertyName("ID")]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsResponse.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsResponse.cs
@@ -1,0 +1,16 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Text.Json.Serialization;
+
+    public class HnsResponse
+    {
+        [JsonPropertyName("Success")]
+        public bool Success { get; set; }
+    }
+
+    public class HnsResponse<T> : HnsResponse
+    {
+        [JsonPropertyName("Output")]
+        public T Output { get; set; } = default!;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsSubnet.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsSubnet.cs
@@ -1,0 +1,18 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json.Serialization;
+
+    public class HnsSubnet
+    {
+        [JsonPropertyName("AddressPrefix")]
+        public string? AddressPrefix { get; set; } = null;
+
+        [JsonPropertyName("GatewayAddress")]
+        public string? GatewayAddress { get; set; } = null;
+
+        [JsonPropertyName("Policies")]
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "This property is used for JSON serialization.")]
+        public HnsSubnetPolicy[] Policies { get; set; } = Array.Empty<HnsSubnetPolicy>();
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/HnsSubnetPolicy.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/HnsSubnetPolicy.cs
@@ -1,0 +1,13 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Text.Json.Serialization;
+
+    public class HnsSubnetPolicy
+    {
+        [JsonPropertyName("Type")]
+        public string? Type { get; set; } = null;
+
+        [JsonPropertyName("VSID")]
+        public int? VSID { get; set; } = null;
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/IHnsApi.cs
+++ b/UET/Redpoint.Windows.HostNetworkingService/IHnsApi.cs
@@ -1,0 +1,36 @@
+﻿namespace Redpoint.Windows.HostNetworkingService
+{
+    using System.Runtime.Versioning;
+
+    [SupportedOSPlatform("windows")]
+    public interface IHnsApi
+    {
+        HnsNetworkWithId[] GetHnsNetworks();
+
+        void NewHnsNetwork(HnsNetwork network);
+
+        void DeleteHnsNetwork(string id);
+
+        HnsEndpointWithId[] GetHnsEndpoints();
+
+        HnsPolicyListWithId[] GetHnsPolicyLists();
+
+        void DeleteHnsPolicyList(string id);
+
+        private static IHnsApi? _instance;
+
+        public static IHnsApi GetInstance()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            if (_instance == null)
+            {
+                _instance = new DefaultHns();
+            }
+            return _instance;
+        }
+    }
+}

--- a/UET/Redpoint.Windows.HostNetworkingService/README.md
+++ b/UET/Redpoint.Windows.HostNetworkingService/README.md
@@ -1,0 +1,12 @@
+# Redpoint.Windows.HostNetworkingSerivce
+
+This library provides managed access to the [Host Networking Service (HNS)](https://learn.microsoft.com/en-us/virtualization/windowscontainers/container-networking/architecture#container-network-management-with-host-network-service) in a way that is compatible with trimming and AOT.
+
+This API currently allows you to:
+
+- List networks
+- Create a new network
+- Delete an existing network
+- Get a list of endpoints
+- Get a list of policy lists
+- Delete an existing policy list

--- a/UET/Redpoint.Windows.HostNetworkingService/Redpoint.Windows.HostNetworkingService.csproj
+++ b/UET/Redpoint.Windows.HostNetworkingService/Redpoint.Windows.HostNetworkingService.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/Common.Build.props" />
+
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/LibraryPackaging.Build.props" />
+	<PropertyGroup>
+		<Description>Provides managed access to the Host Networking Service (HNS) API in Windows via COM, in a trim and AOT compatible way.</Description>
+		<PackageTags>hns</PackageTags>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+	</PropertyGroup>
+
+</Project>

--- a/UET/UET.sln
+++ b/UET/UET.sln
@@ -350,6 +350,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.ThirdParty.JUnit.X
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.Uet.BuildPipeline.Executors.Jenkins", "Redpoint.Uet.BuildPipeline.Executors.Jenkins\Redpoint.Uet.BuildPipeline.Executors.Jenkins.csproj", "{C63FDDD4-A4D2-4DCE-B51C-4552CB968A08}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.Windows.HostNetworkingService.Tests", "Redpoint.Windows.HostNetworkingService.Tests\Redpoint.Windows.HostNetworkingService.Tests.csproj", "{91801BB9-7215-420E-B7FB-A7F58E1BB18F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.Windows.HostNetworkingService", "Redpoint.Windows.HostNetworkingService\Redpoint.Windows.HostNetworkingService.csproj", "{CAA2B8FB-D8AB-3936-C9FF-99556D1C2850}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -948,6 +952,14 @@ Global
 		{C63FDDD4-A4D2-4DCE-B51C-4552CB968A08}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C63FDDD4-A4D2-4DCE-B51C-4552CB968A08}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C63FDDD4-A4D2-4DCE-B51C-4552CB968A08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91801BB9-7215-420E-B7FB-A7F58E1BB18F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91801BB9-7215-420E-B7FB-A7F58E1BB18F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91801BB9-7215-420E-B7FB-A7F58E1BB18F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91801BB9-7215-420E-B7FB-A7F58E1BB18F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAA2B8FB-D8AB-3936-C9FF-99556D1C2850}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAA2B8FB-D8AB-3936-C9FF-99556D1C2850}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAA2B8FB-D8AB-3936-C9FF-99556D1C2850}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAA2B8FB-D8AB-3936-C9FF-99556D1C2850}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1071,6 +1083,8 @@ Global
 		{F0F97AC5-7955-4223-AE03-5DF12547B777} = {39698A12-7C9B-47F5-BA1A-9F4884A770AF}
 		{1E968B45-5B0A-488A-A0F3-8FBC41F41549} = {39698A12-7C9B-47F5-BA1A-9F4884A770AF}
 		{C63FDDD4-A4D2-4DCE-B51C-4552CB968A08} = {1AE4AFCD-0F49-4CEA-8439-F1AAA2CDD183}
+		{91801BB9-7215-420E-B7FB-A7F58E1BB18F} = {0BF83468-3C95-4B7E-AE5A-01E54464DC93}
+		{CAA2B8FB-D8AB-3936-C9FF-99556D1C2850} = {0BF83468-3C95-4B7E-AE5A-01E54464DC93}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8598A278-509A-48A6-A7B3-3E3B0D1011F1}


### PR DESCRIPTION
This provides a managed library on top of the [HNS API](https://learn.microsoft.com/en-us/virtualization/windowscontainers/container-networking/architecture#container-network-management-with-host-network-service) for managing container networks on Windows. It connects to the COM object exposed by Windows Containers, while still being compatible with trimming and AOT, which is necessary for UET.