### PR TITLE
Automatically upgrade UET on RKM start, and restart service if necessary

### DIFF
--- a/UET/uet/Commands/Upgrade/UpgradeCommand.cs
+++ b/UET/uet/Commands/Upgrade/UpgradeCommand.cs
@@ -70,13 +70,13 @@
                 {
                     try
                     {
-                        return await UpgradeCommandImplementation.PerformUpgradeAsync(
+                        return (await UpgradeCommandImplementation.PerformUpgradeAsync(
                             _progressFactory,
                             _monitorFactory,
                             _logger,
                             version,
                             doNotSetAsCurrent,
-                            context.GetCancellationToken()).ConfigureAwait(false);
+                            context.GetCancellationToken()).ConfigureAwait(false)).ExitCode;
                     }
                     catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.GatewayTimeout)
                     {


### PR DESCRIPTION
This ensures RKM is always running the latest version when it starts up, which helps clusters recover faster if we ship an update that breaks RKM.