### PR TITLE
Try using CoreV1.ListNamespaceAsync instead of Version.GetCodeAsync

### DIFF
--- a/UET/Redpoint.KubernetesManager/Services/DefaultKubernetesClientFactory.cs
+++ b/UET/Redpoint.KubernetesManager/Services/DefaultKubernetesClientFactory.cs
@@ -23,8 +23,8 @@
             {
                 try
                 {
-                    var code = await kubernetes.Version.GetCodeAsync(cancellationToken);
-                    _logger.LogInformation($"Connected to API server, Kubernetes is running version: {code.Major}.{code.Minor}");
+                    var code = await kubernetes.CoreV1.ListNamespaceAsync(cancellationToken: cancellationToken);
+                    // _logger.LogInformation($"Connected to API server, Kubernetes is running version: {code.Major}.{code.Minor}");
                     return kubernetes;
                 }
                 catch (HttpRequestException ex)


### PR DESCRIPTION
I'm hoping that Version.GetCodeAsync is just special cased in some way that breaks it's usage in AOT scenarios, because I can't otherwise see why this would fail as it does.