### PR TITLE
Prevent Fab and OnlineSubsystemEOS plugins from being enabled by default

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/BuildGraph_Plugin.xml
@@ -222,12 +222,12 @@ $(PackageExclude);
       <Node Name="$(NodeName)" Requires="$(InputFiles)" Produces="$(OutputTag)">
         <WriteTextFile
           File="$(TempPath)/$(AssembledProjectName)/$(AssembledProjectName).uproject"
-          Text="{ &quot;FileVersion&quot;: 3, &quot;Plugins&quot;: [ { &quot;Name&quot;: &quot;$(PluginName)&quot;, &quot;Enabled&quot;: true } ] }"
+          Text="{ &quot;FileVersion&quot;: 3, &quot;Plugins&quot;: [ { &quot;Name&quot;: &quot;$(PluginName)&quot;, &quot;Enabled&quot;: true }, { &quot;Name&quot;: &quot;Fab&quot;, &quot;Enabled&quot;: false }, { &quot;Name&quot;: &quot;OnlineSubsystemEOS&quot;, &quot;Enabled&quot;: false } ] }"
           If="'$(IsForGauntlet)' != 'true'"
         />
         <WriteTextFile
           File="$(TempPath)/$(AssembledProjectName)/$(AssembledProjectName).uproject"
-          Text="{ &quot;FileVersion&quot;: 3, &quot;Plugins&quot;: [ { &quot;Name&quot;: &quot;$(PluginName)&quot;, &quot;Enabled&quot;: true }, { &quot;Name&quot;: &quot;Gauntlet&quot;, &quot;Enabled&quot;: true } ] }"
+          Text="{ &quot;FileVersion&quot;: 3, &quot;Plugins&quot;: [ { &quot;Name&quot;: &quot;$(PluginName)&quot;, &quot;Enabled&quot;: true }, { &quot;Name&quot;: &quot;Fab&quot;, &quot;Enabled&quot;: false }, { &quot;Name&quot;: &quot;OnlineSubsystemEOS&quot;, &quot;Enabled&quot;: false }, { &quot;Name&quot;: &quot;Gauntlet&quot;, &quot;Enabled&quot;: true } ] }"
           If="'$(IsForGauntlet)' == 'true'"
         />
         <Tag


### PR DESCRIPTION
This explicitly turns off these plugins when assembling test projects for plugins in 5.6 and later.