### PR TITLE
Add experimental UET_USE_LESS_UNIQUE_RESERVATION_NAMES_FOR_GIT option

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Executors.GitLab/GitLabBuildNodeExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Executors.GitLab/GitLabBuildNodeExecutor.cs
@@ -74,7 +74,21 @@
 
             var repository = System.Environment.GetEnvironmentVariable("CI_REPOSITORY_URL")!;
             var commit = System.Environment.GetEnvironmentVariable("CI_COMMIT_SHA")!;
+            var branch = System.Environment.GetEnvironmentVariable("CI_MERGE_REQUEST_ID");
+            if (string.IsNullOrWhiteSpace(branch))
+            {
+                branch = System.Environment.GetEnvironmentVariable("CI_COMMIT_REF_NAME");
+            }
+            if (string.IsNullOrWhiteSpace(branch))
+            {
+                branch = commit;
+            }
             var executingNode = new NodeNameExecutionState();
+
+            if (System.Environment.GetEnvironmentVariable("UET_USE_LESS_UNIQUE_RESERVATION_NAMES_FOR_GIT") == "1")
+            {
+                _logger.LogInformation($"Using commit hash '{commit}' for checkout and '{branch}' for reservation name.");
+            }
 
             _logger.LogTrace("Starting execution of nodes...");
             try
@@ -238,6 +252,7 @@
                         {
                             RepositoryUrl = repository,
                             RepositoryCommitOrRef = commit,
+                            RepositoryBranchForReservationParameters = branch,
                             AdditionalFolderLayers = Array.Empty<string>(),
                             AdditionalFolderZips = Array.Empty<string>(),
                             WorkspaceDisambiguators = nodeNames,
@@ -281,6 +296,7 @@
                                 {
                                     RepositoryUrl = repository,
                                     RepositoryCommitOrRef = commit,
+                                    RepositoryBranchForReservationParameters = branch,
                                     AdditionalFolderLayers = Array.Empty<string>(),
                                     AdditionalFolderZips = Array.Empty<string>(),
                                     WorkspaceDisambiguators = nodeNames,

--- a/UET/Redpoint.Uet.BuildPipeline.Executors.Jenkins/JenkinsBuildNodeExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Executors.Jenkins/JenkinsBuildNodeExecutor.cs
@@ -76,6 +76,8 @@
 
             var repository = System.Environment.GetEnvironmentVariable("UET_GIT_URL")!;
             var commit = System.Environment.GetEnvironmentVariable("UET_GIT_REF")!;
+            // @todo: This should be the branch name or "pull request ID".
+            var branch = commit;
             var executingNode = new NodeNameExecutionState();
 
             _logger.LogTrace("Starting execution of nodes...");
@@ -240,6 +242,7 @@
                         {
                             RepositoryUrl = repository,
                             RepositoryCommitOrRef = commit,
+                            RepositoryBranchForReservationParameters = branch,
                             AdditionalFolderLayers = Array.Empty<string>(),
                             AdditionalFolderZips = Array.Empty<string>(),
                             WorkspaceDisambiguators = nodeNames,
@@ -283,6 +286,7 @@
                                 {
                                     RepositoryUrl = repository,
                                     RepositoryCommitOrRef = commit,
+                                    RepositoryBranchForReservationParameters = branch,
                                     AdditionalFolderLayers = Array.Empty<string>(),
                                     AdditionalFolderZips = Array.Empty<string>(),
                                     WorkspaceDisambiguators = nodeNames,

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Prepare/Project/DownloadPlugin/DownloadPluginProjectPrepareProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Prepare/Project/DownloadPlugin/DownloadPluginProjectPrepareProvider.cs
@@ -111,6 +111,7 @@
                     {
                         RepositoryUrl = sensitiveSelectedSourceGitUrl!,
                         RepositoryCommitOrRef = selectedSource.GitRef!,
+                        RepositoryBranchForReservationParameters = selectedSource.GitRef!,
                         WorkspaceDisambiguators = Array.Empty<string>(),
                         AdditionalFolderLayers = Array.Empty<string>(),
                         AdditionalFolderZips = Array.Empty<string>(),

--- a/UET/Redpoint.Uet.BuildPipeline/Executors/Engine/DefaultEngineWorkspaceProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/Executors/Engine/DefaultEngineWorkspaceProvider.cs
@@ -64,6 +64,7 @@
                     {
                         RepositoryUrl = buildEngineSpecification._gitUrl!,
                         RepositoryCommitOrRef = buildEngineSpecification._gitCommit,
+                        RepositoryBranchForReservationParameters = buildEngineSpecification._gitCommit,
                         AdditionalFolderLayers = Array.Empty<string>(),
                         AdditionalFolderZips = buildEngineSpecification._gitConsoleZips!,
                         WorkspaceDisambiguators = new[] { workspaceSuffix },

--- a/UET/Redpoint.Uet.Workspace.Tests/PhysicalGitCheckoutTests.cs
+++ b/UET/Redpoint.Uet.Workspace.Tests/PhysicalGitCheckoutTests.cs
@@ -68,6 +68,7 @@
                 {
                     RepositoryUrl = "https://src.redpoint.games/redpointgames/examples",
                     RepositoryCommitOrRef = "main",
+                    RepositoryBranchForReservationParameters = "main",
                     WorkspaceDisambiguators = Array.Empty<string>(),
                     AdditionalFolderLayers = Array.Empty<string>(),
                     AdditionalFolderZips = Array.Empty<string>(),
@@ -126,6 +127,7 @@
                 {
                     RepositoryUrl = "https://src.redpoint.games/redpointgames/examples",
                     RepositoryCommitOrRef = "main",
+                    RepositoryBranchForReservationParameters = "main",
                     WorkspaceDisambiguators = Array.Empty<string>(),
                     AdditionalFolderLayers = Array.Empty<string>(),
                     AdditionalFolderZips = Array.Empty<string>(),
@@ -148,6 +150,7 @@
                 {
                     RepositoryUrl = "https://src.redpoint.games/redpointgames/examples",
                     RepositoryCommitOrRef = "main",
+                    RepositoryBranchForReservationParameters = "main",
                     WorkspaceDisambiguators = Array.Empty<string>(),
                     AdditionalFolderLayers = Array.Empty<string>(),
                     AdditionalFolderZips = Array.Empty<string>(),
@@ -219,6 +222,7 @@
                 {
                     RepositoryUrl = "ssh://git@github.com/RedpointGames/uet",
                     RepositoryCommitOrRef = "main",
+                    RepositoryBranchForReservationParameters = "main",
                     WorkspaceDisambiguators = Array.Empty<string>(),
                     AdditionalFolderLayers = Array.Empty<string>(),
                     AdditionalFolderZips = Array.Empty<string>(),
@@ -274,6 +278,7 @@
                 {
                     RepositoryUrl = "https://src.redpoint.games/redpointgames/uet",
                     RepositoryCommitOrRef = "main",
+                    RepositoryBranchForReservationParameters = "main",
                     WorkspaceDisambiguators = Array.Empty<string>(),
                     AdditionalFolderLayers = Array.Empty<string>(),
                     AdditionalFolderZips = Array.Empty<string>(),

--- a/UET/Redpoint.Uet.Workspace/DefaultWorkspaceProvider.cs
+++ b/UET/Redpoint.Uet.Workspace/DefaultWorkspaceProvider.cs
@@ -134,10 +134,15 @@
 
         private async Task<IWorkspace> AllocateGitAsync(GitWorkspaceDescriptor descriptor, CancellationToken cancellationToken)
         {
+            var reservationParameters =
+                Environment.GetEnvironmentVariable("UET_USE_LESS_UNIQUE_RESERVATION_NAMES_FOR_GIT") == "1"
+                ? _parameterGenerator.ConstructReservationParameters([descriptor.RepositoryUrl, descriptor.RepositoryBranchForReservationParameters])
+                : _parameterGenerator.ConstructReservationParameters([descriptor.RepositoryUrl, descriptor.RepositoryCommitOrRef]);
+
             var usingReservation = false;
             var reservation = await _reservationManager.ReserveAsync(
                 "PhysicalGit",
-                _parameterGenerator.ConstructReservationParameters([descriptor.RepositoryUrl, descriptor.RepositoryCommitOrRef])).ConfigureAwait(false);
+                reservationParameters).ConfigureAwait(false);
             try
             {
                 _logger.LogInformation($"Creating physical Git workspace: {reservation.ReservedPath}");

--- a/UET/Redpoint.Uet.Workspace/Descriptors/GitWorkspaceDescriptor.cs
+++ b/UET/Redpoint.Uet.Workspace/Descriptors/GitWorkspaceDescriptor.cs
@@ -9,6 +9,8 @@
 
         public required string RepositoryCommitOrRef { get; set; }
 
+        public required string RepositoryBranchForReservationParameters { get; set; }
+
         public required IReadOnlyList<string> AdditionalFolderLayers { get; set; }
 
         public required IReadOnlyList<string> AdditionalFolderZips { get; set; }

--- a/UET/uet/Commands/Internal/EngineCheckout/EngineCheckoutCommand.cs
+++ b/UET/uet/Commands/Internal/EngineCheckout/EngineCheckoutCommand.cs
@@ -61,6 +61,7 @@
                     {
                         RepositoryUrl = context.ParseResult.GetValueForOption(_options.RepositoryUri)!,
                         RepositoryCommitOrRef = context.ParseResult.GetValueForOption(_options.Branch)!,
+                        RepositoryBranchForReservationParameters = context.ParseResult.GetValueForOption(_options.Branch)!,
                         AdditionalFolderLayers = [],
                         AdditionalFolderZips = [],
                         WorkspaceDisambiguators = [],


### PR DESCRIPTION
When this environment variable is set to '1' on the build server, UET will reuse workspaces where the Git branch or merge request ID is the same, instead of only reusing workspaces where the Git commit is the same.