### PR TITLE
Ensure executable extensions are lowercase when paths are resolved

### DIFF
--- a/UET/Redpoint.PathResolution/DefaultPathResolver.cs
+++ b/UET/Redpoint.PathResolution/DefaultPathResolver.cs
@@ -18,9 +18,9 @@
                     {
                         foreach (var pathExt in pathExts)
                         {
-                            if (File.Exists(Path.Combine(path, $"{binaryName}{pathExt}")))
+                            if (File.Exists(Path.Combine(path, $"{binaryName}{pathExt.ToLowerInvariant()}")))
                             {
-                                return Task.FromResult(Path.Combine(path, $"{binaryName}{pathExt}"));
+                                return Task.FromResult(Path.Combine(path, $"{binaryName}{pathExt.ToLowerInvariant()}"));
                             }
                         }
                     }


### PR DESCRIPTION
This works around extremely bizarre behaviour in kubectl where running 'kubectl.exe --context=blah' works but 'kubectl.EXE --context=blah' does not on Windows.