### PR TITLE
Enforce Firestore limits on IN and NOT-IN queries client side

### DIFF
--- a/UET/Redpoint.CloudFramework/Repository/Converters/Expression/DefaultExpressionConverter.cs
+++ b/UET/Redpoint.CloudFramework/Repository/Converters/Expression/DefaultExpressionConverter.cs
@@ -227,12 +227,20 @@
                     callExpression.Arguments.Count == 2)
                 {
                     var targetValue = Expression.Lambda<Func<string[]>>(callExpression.Arguments[1]).Compile()();
+                    if (targetValue.Length > 30)
+                    {
+                        throw new InvalidOperationException("The target array for an 'IsOneOfString' has more than 30 entries to match against. Firestore only permits up to 30 entries for an 'IN' query.");
+                    }
                     return Filter.In(propertyInfo.Name, targetValue);
                 }
                 else if (callExpression.Method == typeof(RepositoryExtensions).GetMethod(nameof(RepositoryExtensions.IsNotOneOfString), BindingFlags.Static | BindingFlags.Public) &&
                     callExpression.Arguments.Count == 2)
                 {
                     var targetValue = Expression.Lambda<Func<string[]>>(callExpression.Arguments[1]).Compile()();
+                    if (targetValue.Length > 10)
+                    {
+                        throw new InvalidOperationException("The target array for an 'IsNotOneOfString' has more than 10 entries to match against. Firestore only permits up to 10 entries for a 'NOT-IN' query.");
+                    }
                     return Filter.NotIn(propertyInfo.Name, targetValue);
                 }
                 else

--- a/UET/Redpoint.CloudFramework/Repository/Extensions/RepositoryExtensions.cs
+++ b/UET/Redpoint.CloudFramework/Repository/Extensions/RepositoryExtensions.cs
@@ -21,13 +21,41 @@
             return values != null && values.Contains(target);
         }
 
+        /// <summary>
+        /// Match if the property is one of the values specified by <paramref name="target"/>. A maximum of 30 values is permitted by Firestore; any more than this and you will receive an error.
+        /// </summary>
+        /// <param name="value">The property to query against.</param>
+        /// <param name="target">The target values that must match in order for an entity to be returned.</param>
+        /// <returns>True if the property value is in the target array.</returns>
         public static bool IsOneOfString(this string? value, string[] target)
         {
+            ArgumentNullException.ThrowIfNull(target);
+
+            // This check is also present in DefaultExpressionConverter, which is what enforces it client side for actual queries.
+            if (target.Length > 30)
+            {
+                throw new InvalidOperationException("The target array for an 'IsOneOfString' has more than 30 entries to match against. Firestore only permits up to 30 entries for an 'IN' query.");
+            }
+
             return value != null && target.Contains(value);
         }
 
+        /// <summary>
+        /// Match if the property is one of the values specified by <paramref name="target"/>. A maximum of 10 values is permitted by Firestore; any more than this and you will receive an error.
+        /// </summary>
+        /// <param name="value">The property to query against.</param>
+        /// <param name="target">The target values that must not match in order for an entity to be returned.</param>
+        /// <returns>True if the property value is not in the target array.</returns>
         public static bool IsNotOneOfString(this string? value, string[] target)
         {
+            ArgumentNullException.ThrowIfNull(target);
+
+            // This check is also present in DefaultExpressionConverter, which is what enforces it client side for actual queries.
+            if (target.Length > 30)
+            {
+                throw new InvalidOperationException("The target array for an 'IsNotOneOfString' has more than 10 entries to match against. Firestore only permits up to 10 entries for a 'NOT-IN' query.");
+            }
+
             return !(value != null && target.Contains(value));
         }
     }


### PR DESCRIPTION
For some reason, the Firestore error for exceeding these limits doesn't propagate out from the repository layer and just results in no entities being returned. Enforce these limits client side before we even run queries.