### PR TITLE
Support Google Play deployment with Fastlane

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/DeploymentProviderRuntimeJson.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/DeploymentProviderRuntimeJson.cs
@@ -4,6 +4,7 @@
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Plugin.BackblazeB2;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Custom;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Docker;
+    using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.GooglePlay;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Meta;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Steam;
     using System.Text.Json.Serialization;
@@ -13,6 +14,7 @@
     [JsonSerializable(typeof(BuildConfigProjectDeploymentCustom))]
     [JsonSerializable(typeof(BuildConfigProjectDeploymentSteam))]
     [JsonSerializable(typeof(BuildConfigProjectDeploymentMeta))]
+    [JsonSerializable(typeof(BuildConfigProjectDeploymentGooglePlay))]
     [JsonSerializable(typeof(BuildConfigProjectDeploymentDocker))]
     internal sealed partial class DeploymentProviderRuntimeJson
     {

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/DeploymentProviderServiceCollections.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/DeploymentProviderServiceCollections.cs
@@ -10,6 +10,7 @@
     using Redpoint.Uet.Configuration;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Meta;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Docker;
+    using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.GooglePlay;
 
     public static class DeploymentProviderServiceCollections
     {
@@ -19,6 +20,7 @@
             services.AddDynamicProvider<BuildConfigProjectDistribution, IDeploymentProvider, CustomProjectDeploymentProvider>();
             services.AddDynamicProvider<BuildConfigProjectDistribution, IDeploymentProvider, SteamProjectDeploymentProvider>();
             services.AddDynamicProvider<BuildConfigProjectDistribution, IDeploymentProvider, MetaProjectDeploymentProvider>();
+            services.AddDynamicProvider<BuildConfigProjectDistribution, IDeploymentProvider, GooglePlayProjectDeploymentProvider>();
             services.AddDynamicProvider<BuildConfigProjectDistribution, IDeploymentProvider, DockerProjectDeploymentProvider>();
         }
     }

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/DeploymentProviderSourceGenerationContext.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/DeploymentProviderSourceGenerationContext.cs
@@ -3,6 +3,7 @@
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Plugin.BackblazeB2;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Custom;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Docker;
+    using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.GooglePlay;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Meta;
     using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Steam;
     using System.Text.Json;
@@ -13,6 +14,7 @@
     [JsonSerializable(typeof(BuildConfigProjectDeploymentCustom))]
     [JsonSerializable(typeof(BuildConfigProjectDeploymentSteam))]
     [JsonSerializable(typeof(BuildConfigProjectDeploymentMeta))]
+    [JsonSerializable(typeof(BuildConfigProjectDeploymentGooglePlay))]
     [JsonSerializable(typeof(BuildConfigProjectDeploymentDocker))]
     internal sealed partial class DeploymentProviderSourceGenerationContext : JsonSerializerContext
     {

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/GooglePlay/BuildConfigProjectDeploymentGooglePlay.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/GooglePlay/BuildConfigProjectDeploymentGooglePlay.cs
@@ -1,0 +1,36 @@
+﻿namespace Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.GooglePlay
+{
+    using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.Package;
+    using System.Text.Json.Serialization;
+
+    internal class BuildConfigProjectDeploymentGooglePlay
+    {
+        /// <summary>
+        /// The package name to deploy to.
+        /// </summary>
+        [JsonPropertyName("PackageName"), JsonRequired]
+        public required string PackageName { get; set; }
+
+        /// <summary>
+        /// One or more tracks to deploy to; entries must be one of 'production', 'beta', 'alpha' or 'internal'. Defaults to just 'internal'.
+        /// </summary>
+        [JsonPropertyName("Tracks")]
+        public string[] Tracks { get; set; } = ["internal"];
+
+        /// <summary>
+        /// The path to the JSON key used to authenticate with the Google Play Developer Console. This should be set up according to Fastlane instructions: https://docs.fastlane.tools/getting-started/android/setup/#collect-your-google-credentials
+        /// 
+        /// This path is relative to the project root. It can also be an absolute path.
+        /// 
+        /// If you set the UET_GOOGLE_PLAY_JSON_KEY_PATH environment variable, it will override this setting. If you don't set this setting, you must provide set the UET_GOOGLE_PLAY_JSON_KEY_PATH environment variable.
+        /// </summary>
+        [JsonPropertyName("JsonKeyPath")]
+        public string? JsonKeyPath { get; set; } = null;
+
+        /// <summary>
+        /// Specifies the packaging target to be deployed.
+        /// </summary>
+        [JsonPropertyName("Package"), JsonRequired]
+        public BuildConfigProjectDeploymentPackage Package { get; set; } = new BuildConfigProjectDeploymentPackage();
+    }
+}

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/GooglePlay/GooglePlayProjectDeploymentProvider.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Project/GooglePlay/GooglePlayProjectDeploymentProvider.cs
@@ -1,0 +1,258 @@
+﻿namespace Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.GooglePlay
+{
+    using Microsoft.Extensions.Logging;
+    using Redpoint.PackageManagement;
+    using Redpoint.ProcessExecution;
+    using Redpoint.ProgressMonitor.Utils;
+    using Redpoint.Reservation;
+    using Redpoint.RuntimeJson;
+    using Redpoint.Uet.BuildGraph;
+    using Redpoint.Uet.BuildPipeline.Providers.Deployment.Project.GooglePlay;
+    using Redpoint.Uet.Configuration;
+    using Redpoint.Uet.Configuration.Dynamic;
+    using Redpoint.Uet.Configuration.Project;
+    using Redpoint.Uet.Workspace.Reservation;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml;
+
+    internal class GooglePlayProjectDeploymentProvider : IProjectDeploymentProvider, IDynamicReentrantExecutor<BuildConfigProjectDistribution, BuildConfigProjectDeploymentGooglePlay>
+    {
+        private readonly ILogger<GooglePlayProjectDeploymentProvider> _logger;
+        private readonly IProcessExecutor _processExecutor;
+        private readonly ISimpleDownloadProgress _simpleDownloadProgress;
+        private readonly IPackageManager _packageManager;
+        private readonly IGlobalMutexReservationManager _globalMutexReservationManager;
+        private readonly IGlobalArgsProvider? _globalArgsProvider;
+
+        public GooglePlayProjectDeploymentProvider(
+            ILogger<GooglePlayProjectDeploymentProvider> logger,
+            IProcessExecutor processExecutor,
+            ISimpleDownloadProgress simpleDownloadProgress,
+            IPackageManager packageManager,
+            IReservationManagerFactory reservationManagerFactory,
+            IGlobalArgsProvider? globalArgsProvider = null)
+        {
+            _logger = logger;
+            _processExecutor = processExecutor;
+            _simpleDownloadProgress = simpleDownloadProgress;
+            _packageManager = packageManager;
+            _globalMutexReservationManager = reservationManagerFactory.CreateGlobalMutexReservationManager();
+            _globalArgsProvider = globalArgsProvider;
+        }
+
+        public string Type => "GooglePlay";
+
+        public IRuntimeJson DynamicSettings { get; } = new DeploymentProviderRuntimeJson(DeploymentProviderSourceGenerationContext.WithStringEnum).BuildConfigProjectDeploymentGooglePlay;
+
+
+        public async Task WriteBuildGraphNodesAsync(
+            IBuildGraphEmitContext context,
+            XmlWriter writer,
+            BuildConfigProjectDistribution buildConfigDistribution,
+            IEnumerable<BuildConfigDynamic<BuildConfigProjectDistribution, IDeploymentProvider>> dynamicSettings)
+        {
+            var castedSettings = dynamicSettings
+                .Select(x => (name: x.Name, manual: x.Manual ?? false, settings: (BuildConfigProjectDeploymentGooglePlay)x.DynamicSettings))
+                .ToList();
+
+            // Emit the nodes to run each deployment.
+            foreach (var (name, manual, settings) in castedSettings)
+            {
+                var stageName = $"{settings.Package.Type}Staged_{settings.Package.Target}_{settings.Package.Platform}_{settings.Package.Configuration}";
+                if (!string.IsNullOrWhiteSpace(settings.Package.CookFlavor))
+                {
+                    stageName = $"{stageName}_{settings.Package.CookFlavor}";
+                }
+
+                await writer.WriteAgentNodeAsync(
+                    new AgentNodeElementProperties
+                    {
+                        AgentStage = $"Deployment {name}",
+                        AgentType = manual ? "Win64_Manual" : "Win64",
+                        NodeName = $"Deployment {name}",
+                        Requires = $"#{stageName};$(DynamicPreDeploymentNodes)",
+                    },
+                    async writer =>
+                    {
+                        await writer.WriteDynamicReentrantSpawnAsync<GooglePlayProjectDeploymentProvider, BuildConfigProjectDistribution, BuildConfigProjectDeploymentGooglePlay>(
+                            this,
+                            context,
+                            $"{settings.Package.Platform}.{name}".Replace(" ", ".", StringComparison.Ordinal),
+                            settings,
+                            new Dictionary<string, string>
+                            {
+                                { "ProjectRoot", "$(ProjectRoot)" },
+                                { "StageDirectory", "$(StageDirectory)" },
+                                { "TempPath", "$(TempPath)" },
+                                { "Timestamp", "$(Timestamp)" },
+                            }).ConfigureAwait(false);
+                        await writer.WriteDynamicNodeAppendAsync(
+                            new DynamicNodeAppendElementProperties
+                            {
+                                NodeName = $"Deployment {name}",
+                            }).ConfigureAwait(false);
+                    }).ConfigureAwait(false);
+            }
+        }
+
+        public async Task<int> ExecuteBuildGraphNodeAsync(
+            object configUnknown,
+            Dictionary<string, string> runtimeSettings,
+            CancellationToken cancellationToken)
+        {
+            var config = (BuildConfigProjectDeploymentGooglePlay)configUnknown;
+
+            var stagePlatform = config.Package.Platform;
+            if (stagePlatform is not "Android" and not "GooglePlay")
+            {
+                _logger.LogError("Only Android/GooglePlay builds can be published to Google Play.");
+                return 1;
+            }
+
+            await using (await _globalMutexReservationManager.ReserveExactAsync("RubyInstall", cancellationToken))
+            {
+                _logger.LogInformation("Installing Ruby...");
+                await _packageManager.InstallOrUpgradePackageToLatestAsync(
+                    "RubyInstallerTeam.RubyWithDevKit.3.4",
+                    cancellationToken);
+
+                _logger.LogInformation("Installing Fastlane...");
+                var gemPath = @"C:\Ruby34-x64\bin\gem.cmd";
+                var installExitCode = await _processExecutor.ExecuteAsync(
+                    new ProcessSpecification
+                    {
+                        FilePath = gemPath,
+                        Arguments = ["install", "fastlane"]
+                    },
+                    CaptureSpecification.Passthrough,
+                    cancellationToken);
+                if (installExitCode != 0)
+                {
+                    return installExitCode;
+                }
+            }
+
+            var jsonKeyPath = Environment.GetEnvironmentVariable("UET_GOOGLE_PLAY_JSON_KEY_PATH");
+            if (string.IsNullOrWhiteSpace(jsonKeyPath))
+            {
+                if (!string.IsNullOrWhiteSpace(config.JsonKeyPath))
+                {
+                    if (Path.IsPathRooted(config.JsonKeyPath))
+                    {
+                        jsonKeyPath = config.JsonKeyPath;
+                    }
+                    else
+                    {
+                        jsonKeyPath = Path.Combine(runtimeSettings["ProjectRoot"], config.JsonKeyPath);
+                    }
+                }
+                else
+                {
+                    _logger.LogError("Missing UET_GOOGLE_PLAY_JSON_KEY_PATH environment variable, which is required for Google Play deployments if you don't set the 'JsonKeyPath' property in the BuildConfig.json file. Set this environment variable on the command line or in your build server configuration.");
+                    return 1;
+                }
+            }
+
+            var fastlanePath = @"C:\Ruby34-x64\bin\fastlane.bat";
+
+            var first = true;
+            foreach (var track in config.Tracks.OrderBy(x => x switch
+            {
+                // Always run out tracks internal -> production, regardless of array order.
+                "internal" => 0,
+                "alpha" => 1,
+                "beta" => 2,
+                "production" => 3,
+                _ => 4
+            }))
+            {
+                _logger.LogInformation($"Deploying to track '{track}'...");
+                var holder = new RetryWithoutUploadHolder();
+            retry:
+                var exitCode = await _processExecutor.ExecuteAsync(
+                    new ProcessSpecification
+                    {
+                        FilePath = fastlanePath,
+                        Arguments =
+                            first
+                                ? ["run", "upload_to_play_store"]
+                                : ["run", "upload_to_play_store", $"version_codes_to_retain:{runtimeSettings["Timestamp"]}", "rollout:1"],
+                        EnvironmentVariables =
+                            first
+                            ? new Dictionary<string, string>
+                            {
+                                { "FASTLANE_OPT_OUT_USAGE", "YES" },
+                                { "LC_ALL", "en_US.UTF-8" },
+                                { "LANG", "en_US.UTF-8" },
+                                { "SUPPLY_PACKAGE_NAME", config.PackageName },
+                                { "SUPPLY_TRACK", track },
+                                { "SUPPLY_JSON_KEY", jsonKeyPath },
+                                { "SUPPLY_AAB", Path.Combine(runtimeSettings["ProjectRoot"], "Binaries", "Android", $"{config.Package.Target}-Android-Shipping.aab") },
+                                { "SUPPLY_VERSION_NAME", DateTimeOffset.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) },
+                                { "SUPPLY_METADATA_PATH", runtimeSettings["TempPath"] },
+                            }
+                            : new Dictionary<string, string>
+                            {
+                                { "FASTLANE_OPT_OUT_USAGE", "YES" },
+                                { "LC_ALL", "en_US.UTF-8" },
+                                { "LANG", "en_US.UTF-8" },
+                                { "SUPPLY_JSON_KEY", jsonKeyPath },
+                                { "SUPPLY_PACKAGE_NAME", config.PackageName },
+                                { "SUPPLY_TRACK", track },
+                                { "SUPPLY_VERSION_NAME", DateTimeOffset.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) },
+                                { "SUPPLY_VERSION_CODE", runtimeSettings["Timestamp"] },
+                            }
+                    },
+                    first
+                        ? CaptureSpecification.CreateFromDelegates(new CaptureSpecificationDelegates
+                        {
+                            ReceiveStdout = (line) =>
+                            {
+                                if (line.Contains("Version code", StringComparison.Ordinal) && line.Contains("has already been used", StringComparison.Ordinal))
+                                {
+                                    holder.RetryWithoutUpload = true;
+                                }
+                                return true;
+                            },
+                            ReceiveStderr = (line) =>
+                            {
+                                if (line.Contains("Version code", StringComparison.Ordinal) && line.Contains("has already been used", StringComparison.Ordinal))
+                                {
+                                    holder.RetryWithoutUpload = true;
+                                }
+                                return true;
+                            },
+                        })
+                        : CaptureSpecification.Passthrough,
+                    cancellationToken);
+                if (exitCode != 0 && holder.RetryWithoutUpload && first)
+                {
+                    // We retry assuming that the version was already uploaded. This allows people to retry build jobs without errors.
+                    _logger.LogInformation("Detected that this version may already have been uploaded by a previous run. Attempting to run Fastlane again with upload skip...");
+                    first = false;
+                    goto retry;
+                }
+                if (exitCode != 0)
+                {
+                    return exitCode;
+                }
+
+                // We don't need to upload on subsequent tracks.
+                first = false;
+            }
+
+            return 0;
+        }
+
+        private class RetryWithoutUploadHolder
+        {
+            public bool RetryWithoutUpload;
+        }
+    }
+}

--- a/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Redpoint.Uet.BuildPipeline.Providers.Deployment.csproj
+++ b/UET/Redpoint.Uet.BuildPipeline.Providers.Deployment/Redpoint.Uet.BuildPipeline.Providers.Deployment.csproj
@@ -13,11 +13,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lib\Redpoint.ThirdParty.B2Net\Redpoint.ThirdParty.B2Net.csproj" />
+    <ProjectReference Include="..\Redpoint.PackageManagement\Redpoint.PackageManagement.csproj" />
     <ProjectReference Include="..\Redpoint.ProcessExecution\Redpoint.ProcessExecution.csproj" />
     <ProjectReference Include="..\Redpoint.ProgressMonitor\Redpoint.ProgressMonitor.csproj" />
     <ProjectReference Include="..\Redpoint.Uet.BuildGraph\Redpoint.Uet.BuildGraph.csproj" />
     <ProjectReference Include="..\Redpoint.Uet.Configuration\Redpoint.Uet.Configuration.csproj" />
     <ProjectReference Include="..\Redpoint.RuntimeJson.SourceGenerator\Redpoint.RuntimeJson.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Redpoint.Uet.Workspace\Redpoint.Uet.Workspace.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It can be used like this in the deployments section:

```json
{
  "Name": "Google Play",
  "Type": "GooglePlay",
  "GooglePlay": {
    "Tracks": ["internal", "alpha"],
    "JsonKeyPath": "path/to/json/file",
    "PackageName": "games.redpoint.MinuteOfMayhem",
    "Package": {
      "Configuration": "Shipping",
      "Platform": "GooglePlay",
      "Target": "MinuteOfMayhem",
      "Type": "Game"
    }
  }
}
```

Instead of setting `JsonKeyPath`, you can set the environment variable `UET_GOOGLE_PLAY_JSON_KEY_PATH` if you want this value provided by a build server.