### PR TITLE
Patch Magick.NET-Q16-HDRI-AnyCPU package reference

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/BuildGraphPatches.json
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/BuildGraphPatches.json
@@ -214,5 +214,53 @@
       }
     ],
     "Output5": "Engine\\Binaries\\DotNET\\UnrealBuildTool\\UnrealBuildTool.dll"
+  },
+  {
+    "File": "Engine\\Source\\Programs\\AutomationTool\\AutomationTool.csproj",
+    "Patches": [
+      {
+        "HandleWindowsNewLines": true,
+        "Find": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.0.0\" />",
+        "Replace": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.7.0\" />"
+      },
+      {
+        "HandleWindowsNewLines": true,
+        "Find": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.0.0\" PrivateAssets=\"all\" />",
+        "Replace": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.7.0\" PrivateAssets=\"all\" />"
+      }
+    ],
+    "Output5": "Engine\\Binaries\\DotNET\\AutomationTool\\AutomationTool.dll"
+  },
+  {
+    "File": "Engine\\Source\\Programs\\AutomationTool\\AutomationUtils\\AutomationUtils.Automation.csproj",
+    "Patches": [
+      {
+        "HandleWindowsNewLines": true,
+        "Find": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.0.0\" />",
+        "Replace": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.7.0\" />"
+      },
+      {
+        "HandleWindowsNewLines": true,
+        "Find": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.0.0\" PrivateAssets=\"all\" />",
+        "Replace": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.7.0\" PrivateAssets=\"all\" />"
+      }
+    ],
+    "Output5": "Engine\\Binaries\\DotNET\\AutomationTool\\AutomationUtils\\AutomationUtils.Automation.dll"
+  },
+  {
+    "File": "Engine\\Source\\Programs\\AutomationTool\\Gauntlet\\Gauntlet.Automation.csproj",
+    "Patches": [
+      {
+        "HandleWindowsNewLines": true,
+        "Find": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.0.0\" />",
+        "Replace": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.7.0\" />"
+      },
+      {
+        "HandleWindowsNewLines": true,
+        "Find": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.0.0\" PrivateAssets=\"all\" />",
+        "Replace": "<PackageReference Include=\"Magick.NET-Q16-HDRI-AnyCPU\" Version=\"14.7.0\" PrivateAssets=\"all\" />"
+      }
+    ],
+    "Output5": "Engine\\Binaries\\DotNET\\AutomationTool\\AutomationScripts\\Gauntlet\\Gauntlet.Automation.dll"
   }
 ]

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/IBuildGraphPatcher.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/IBuildGraphPatcher.cs
@@ -2,7 +2,7 @@
 {
     using System.Threading.Tasks;
 
-    internal interface IBuildGraphPatcher
+    public interface IBuildGraphPatcher
     {
         Task PatchBuildGraphAsync(string enginePath, bool isEngineBuild);
     }

--- a/UET/uet/Commands/Internal/InternalCommand.cs
+++ b/UET/uet/Commands/Internal/InternalCommand.cs
@@ -34,6 +34,7 @@
     using UET.Commands.Internal.CMakeUbaRun;
     using UET.Commands.Internal.EnginePerforceToGit;
     using UET.Commands.Internal.Rkm;
+    using UET.Commands.Internal.Patch;
 
     internal sealed class InternalCommand
     {
@@ -76,6 +77,7 @@
                 EnginePerforceToGitCommand.CreateEnginePerforceToGitCommand(),
                 InstallXcodeCommand.CreateInstallXcodeCommand(),
                 RkmServiceCommand.CreateRkmServiceCommand(),
+                PatchCommand.CreatePatchCommand(),
             };
 
             var command = new Command("internal", "Internal commands used by UET when it needs to call back into itself.");

--- a/UET/uet/Commands/Internal/Patch/PatchCommand.cs
+++ b/UET/uet/Commands/Internal/Patch/PatchCommand.cs
@@ -1,0 +1,56 @@
+﻿namespace UET.Commands.Internal.Patch
+{
+    using Microsoft.Extensions.Logging;
+    using Redpoint.Uet.BuildPipeline.BuildGraph.Patching;
+    using System;
+    using System.Collections.Generic;
+    using System.CommandLine;
+    using System.CommandLine.Invocation;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    internal sealed class PatchCommand
+    {
+        internal sealed class Options
+        {
+            public Option<string> EnginePath;
+
+            public Options()
+            {
+                EnginePath = new Option<string>("--engine-path");
+            }
+        }
+
+        public static Command CreatePatchCommand()
+        {
+            var options = new Options();
+            var command = new Command("patch");
+            command.AddAllOptions(options);
+            command.AddCommonHandler<PatchCommandInstance>(options);
+            return command;
+        }
+
+        private sealed class PatchCommandInstance : ICommandInstance
+        {
+            private readonly IBuildGraphPatcher _patcher;
+            private readonly Options _options;
+
+            public PatchCommandInstance(
+                IBuildGraphPatcher patcher,
+                Options options)
+            {
+                _patcher = patcher;
+                _options = options;
+            }
+
+            public async Task<int> ExecuteAsync(InvocationContext context)
+            {
+                await _patcher.PatchBuildGraphAsync(
+                    context.ParseResult.GetValueForOption(_options.EnginePath)!,
+                    false);
+                return 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This should fix CVE warnings when building against 5.6