### PR TITLE
Add 'run-containerd' for running containerd as a separate service

### DIFF
--- a/UET/Directory.Packages.props
+++ b/UET/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Redpoint.AutoDiscovery.Win64" Version="2024.1358.192" />
     <PackageVersion Include="Redpoint.Logging.Mac.Native" Version="2024.1358.192" />
     <PackageVersion Include="Redpoint.ThirdParty.LibGit2Sharp" Version="2023.177.63629" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="9.0.7" />
     <!-- LINQ async support for older frameworks -->
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <!-- gRPC -->

--- a/UET/Redpoint.KubernetesManager.Tests/ManifestTests.cs
+++ b/UET/Redpoint.KubernetesManager.Tests/ManifestTests.cs
@@ -1,0 +1,121 @@
+﻿namespace Redpoint.KubernetesManager.Tests
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestPlatform.Utilities;
+    using Redpoint.Concurrency;
+    using Redpoint.KubernetesManager.Services;
+    using Redpoint.KubernetesManager.Services.Manifest;
+    using System.Net;
+    using System.Net.WebSockets;
+    using System.Text;
+    using System.Text.Json;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ManifestTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ManifestTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task TestManifestUpdates()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(builder =>
+            {
+                builder.ClearProviders();
+                builder.SetMinimumLevel(LogLevel.Trace);
+                builder.AddXUnit(_output);
+            });
+            services.AddSingleton<IGenericManifestClient, DefaultGenericManifestClient>();
+
+            var client = services.BuildServiceProvider().GetRequiredService<IGenericManifestClient>();
+
+            using var cts = new CancellationTokenSource();
+
+            // Start our client task that polls for updates.
+            var updatesReceived = new List<TestManifest>();
+            var cancellationsReceived = new List<bool>();
+            var clientTask = Task.Run(
+                async () => await client.RegisterAndRunWithManifestAsync<TestManifest>(
+                    new Uri("ws://127.0.0.1:52934"),
+                    null,
+                    TestManifestJsonSerializerContext.Default.TestManifest,
+                    async (testManifest, cancellationToken) =>
+                    {
+                        updatesReceived.Add(testManifest);
+                        try
+                        {
+                            await Task.Delay(-1, cancellationToken);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            cancellationsReceived.Add(true);
+                        }
+                    },
+                    cts.Token),
+                cts.Token);
+
+            // Start our local web server.
+            using var listener = new HttpListener();
+            listener.Prefixes.Add($"http://127.0.0.1:52934/");
+            listener.Start();
+            try
+            {
+                var context = await listener.GetContextAsync().AsCancellable(cts.Token);
+
+                if (context.Request.IsWebSocketRequest)
+                {
+                    var webSocket = await context.AcceptWebSocketAsync(null);
+                    await webSocket.WebSocket.SendAsync(
+                        Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestManifest { Value = 1 }, TestManifestJsonSerializerContext.Default.TestManifest)),
+                        WebSocketMessageType.Text,
+                        true,
+                        cts.Token);
+                    await Task.Delay(500);
+                    Assert.Single(updatesReceived);
+                    Assert.Equal(1, updatesReceived[0].Value);
+                    Assert.Empty(cancellationsReceived);
+                    await webSocket.WebSocket.SendAsync(
+                        Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestManifest { Value = 2 }, TestManifestJsonSerializerContext.Default.TestManifest)),
+                        WebSocketMessageType.Text,
+                        true,
+                        cts.Token);
+                    await Task.Delay(500);
+                    Assert.Equal(2, updatesReceived.Count);
+                    Assert.Equal(2, updatesReceived[1].Value);
+                    Assert.Single(cancellationsReceived);
+                }
+                else
+                {
+                    context.Response.StatusCode = 400;
+                    context.Response.Close();
+                }
+            }
+            finally
+            {
+                listener.Stop();
+            }
+
+            cts.Cancel();
+
+            try
+            {
+                await clientTask;
+            }
+            catch
+            {
+            }
+
+            Assert.Equal(2, updatesReceived.Count);
+            Assert.Equal(2, updatesReceived[1].Value);
+            Assert.Equal(2, cancellationsReceived.Count);
+        }
+    }
+}

--- a/UET/Redpoint.KubernetesManager.Tests/Redpoint.KubernetesManager.Tests.csproj
+++ b/UET/Redpoint.KubernetesManager.Tests/Redpoint.KubernetesManager.Tests.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/Common.Build.props" />
+
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/XunitTesting.Build.props" />
+
+	<ItemGroup>
+		<ProjectReference Include="..\Redpoint.KubernetesManager\Redpoint.KubernetesManager.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/UET/Redpoint.KubernetesManager.Tests/TestManifest.cs
+++ b/UET/Redpoint.KubernetesManager.Tests/TestManifest.cs
@@ -1,0 +1,10 @@
+﻿namespace Redpoint.KubernetesManager.Tests
+{
+    using System.Text.Json.Serialization;
+
+    internal class TestManifest
+    {
+        [JsonPropertyName("value")]
+        public long Value { get; set; }
+    }
+}

--- a/UET/Redpoint.KubernetesManager.Tests/TestManifestJsonSerializerContext.cs
+++ b/UET/Redpoint.KubernetesManager.Tests/TestManifestJsonSerializerContext.cs
@@ -1,0 +1,9 @@
+﻿namespace Redpoint.KubernetesManager.Tests
+{
+    using System.Text.Json.Serialization;
+
+    [JsonSerializable(typeof(TestManifest))]
+    internal partial class TestManifestJsonSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/UET/Redpoint.KubernetesManager/AssemblyTestProperties.cs
+++ b/UET/Redpoint.KubernetesManager/AssemblyTestProperties.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Redpoint.KubernetesManager.Tests")]

--- a/UET/Redpoint.KubernetesManager/Components/ContainerdComponent.cs
+++ b/UET/Redpoint.KubernetesManager/Components/ContainerdComponent.cs
@@ -9,37 +9,28 @@
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
+    using Redpoint.ServiceControl;
 
     /// <summary>
     /// The containerd component sets up and runs the containerd process.
     /// </summary>
-    internal class ContainerdComponent : IComponent, IDisposable
+    internal class ContainerdComponent : IComponent
     {
-        private readonly ILogger<ContainerdComponent> _logger;
-        private readonly IResourceManager _resourceManager;
+        private readonly IServiceControl _serviceControl;
+        private readonly IRkmVersionProvider _rkmVersionProvider;
         private readonly IPathProvider _pathProvider;
-        private readonly IProcessMonitorFactory _processMonitorFactory;
-        private readonly IWindowsHcsService? _hcsService;
-        private readonly CancellationTokenSource _containerdReadyToShutdown;
+        private readonly ILogger<ContainerdComponent> _logger;
 
         public ContainerdComponent(
-            ILogger<ContainerdComponent> logger,
-            IResourceManager resourceManager,
+            IServiceControl serviceControl,
+            IRkmVersionProvider rkmVersionProvider,
             IPathProvider pathProvider,
-            IProcessMonitorFactory processMonitorFactory,
-            IWindowsHcsService? hcsService = null)
+            ILogger<ContainerdComponent> logger)
         {
-            _logger = logger;
-            _resourceManager = resourceManager;
+            _serviceControl = serviceControl;
+            _rkmVersionProvider = rkmVersionProvider;
             _pathProvider = pathProvider;
-            _processMonitorFactory = processMonitorFactory;
-            _hcsService = hcsService;
-            _containerdReadyToShutdown = new CancellationTokenSource();
-        }
-
-        public void Dispose()
-        {
-            ((IDisposable)_containerdReadyToShutdown).Dispose();
+            _logger = logger;
         }
 
         public void RegisterSignals(IRegistrationContext context)
@@ -50,175 +41,58 @@
 
         private async Task OnStartedAsync(IContext context, IAssociatedData? data, CancellationToken cancellationToken)
         {
-            await context.WaitForFlagAsync(WellKnownFlags.AssetsReady);
+            var serviceName = OperatingSystem.IsWindows() ? "RKM - Containerd" : "rkm-containerd";
 
-            _logger.LogInformation("Setting up containerd configuration...");
-            if (OperatingSystem.IsLinux())
+            Directory.CreateDirectory(Path.Combine(_pathProvider.RKMRoot, "cache"));
+
+            var arguments = $"\"{_rkmVersionProvider.UetFilePath}\" cluster run-containerd --manifest-path \"{Path.Combine(_pathProvider.RKMRoot, "cache", "containerd-manifest.json")}\"";
+
+            var installed = false;
+            if (await _serviceControl.IsServiceInstalled(serviceName))
             {
-                await _resourceManager.ExtractResource(
-                    "containerd-config-linux.toml",
-                    Path.Combine(_pathProvider.RKMRoot, "containerd-state", "config.toml"),
-                    new Dictionary<string, string>
+                var result = await _serviceControl.GetServiceExecutableAndArguments(serviceName);
+                if (result == arguments)
+                {
+                    _logger.LogInformation("containerd service is already installed correctly.");
+                    installed = true;
+                }
+                else
+                {
+                    if (await _serviceControl.IsServiceRunning(serviceName))
                     {
-                        { "__CONTAINERD_ROOT__", Path.Combine(_pathProvider.RKMRoot, "containerd-state") },
-                        { "__RUNC_ROOT__", Path.Combine(_pathProvider.RKMRoot, "runc") },
-                        { "__CNI_PLUGINS_ROOT__", Path.Combine(_pathProvider.RKMRoot, "cni-plugins") }
-                    });
-            }
-            else if (OperatingSystem.IsWindows())
-            {
-                await _resourceManager.ExtractResource(
-                    "containerd-config-windows.toml",
-                    Path.Combine(_pathProvider.RKMRoot, "containerd-state", "config.toml"),
-                    new Dictionary<string, string>
-                    {
-                        { "__CONTAINERD_ROOT__", Path.Combine(_pathProvider.RKMRoot, "containerd-state").Replace("\\", "\\\\", StringComparison.Ordinal) },
-                        { "__CNI_PLUGINS_ROOT__", Path.Combine(_pathProvider.RKMRoot, "cni-plugins").Replace("\\", "\\\\", StringComparison.Ordinal) }
-                    });
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
+                        _logger.LogInformation("containerd service is being stopped so it can be reinstalled.");
+                        await _serviceControl.StopService(serviceName);
+                    }
+
+                    _logger.LogInformation("containerd service is being uninstalled because the command line arguments need to change.");
+                    await _serviceControl.UninstallService(serviceName);
+                }
             }
 
-            _logger.LogInformation("Starting containerd and keeping it running...");
-            var containerdMonitor = _processMonitorFactory.CreatePerpetualProcess(new ProcessSpecification(
-                filename: Path.Combine(_pathProvider.RKMRoot, "containerd", "bin", "containerd"),
-                arguments: new[]
-                {
-                    "--config",
-                    Path.Combine(_pathProvider.RKMRoot, "containerd-state", "config.toml"),
-                    "--log-level",
-                    "debug"
-                }));
+            if (!installed)
+            {
+                await _serviceControl.InstallService(
+                    serviceName,
+                    "Runs containerd for RKM.",
+                    arguments,
+                    manualStart: true);
+            }
 
-            // Now we run two tasks in parallel:
-            // - One that watches containerd to exit, on our custom cancellation token
-            // - Another which waits until kubelet has stopped and cleans up containers
-            //   before telling containerd to actually exit.
-            await Task.WhenAll(
-                Task.Run(async () =>
-                {
-                    try
-                    {
-                        // Since we want to clean up containers, we don't shutdown containerd
-                        // immediately on process stop. Instead we raise this cancellation
-                        // token once we've finished our ctr calls.
-                        await containerdMonitor.RunAsync(_containerdReadyToShutdown.Token);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // This is expected when containerd stops, and we don't want to
-                        // prevent the second task from finishing up it's WaitForFlagAsync.
-                    }
-                    finally
-                    {
-                        context.SetFlag(WellKnownFlags.ContainerdStopped);
-                    }
-                }, CancellationToken.None),
-                Task.Run(async () =>
-                {
-                    // Wait for the kubelet to stop.
-                    await context.WaitForUninterruptableFlagAsync(WellKnownFlags.KubeletStopped);
-
-                    // Use ctr to delete all of the containers.
-                    _logger.LogInformation($"Fetching a list of containers to stop...");
-                    var listProcess = Process.Start(new ProcessStartInfo
-                    {
-                        FileName = Path.Combine(_pathProvider.RKMRoot, "containerd", "bin", "ctr"),
-                        ArgumentList =
-                        {
-                            "--namespace",
-                            "k8s.io",
-                            "c",
-                            "list"
-                        },
-                        CreateNoWindow = true,
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true
-                    });
-                    var listLines = (await listProcess!.StandardOutput.ReadToEndAsync()).Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
-                    var containerIds = new List<string>();
-                    var containerRegex = new Regex("^([a-f0-9]+)\\s");
-                    foreach (var line in listLines)
-                    {
-                        var match = containerRegex.Match(line);
-                        if (match.Success)
-                        {
-                            containerIds.Add(match.Groups[1].Value);
-                        }
-                    }
-
-                    _logger.LogInformation($"{containerIds.Count} containers to terminate.");
-                    foreach (var containerId in containerIds)
-                    {
-                        _logger.LogInformation($"Deleting container: {containerId}");
-                        var deleteProcess = Process.Start(new ProcessStartInfo
-                        {
-                            FileName = Path.Combine(_pathProvider.RKMRoot, "containerd", "bin", "ctr"),
-                            ArgumentList =
-                            {
-                                "--namespace",
-                                "k8s.io",
-                                "c",
-                                "delete",
-                                containerId,
-                            },
-                            CreateNoWindow = true,
-                            UseShellExecute = false
-                        });
-                        await deleteProcess!.WaitForExitAsync();
-                    }
-
-                    _logger.LogInformation($"Containers have been terminated, now ready to shutdown containerd.");
-                    _containerdReadyToShutdown.Cancel();
-
-                    _logger.LogInformation($"Waiting for containerd to stop...");
-                    await context.WaitForUninterruptableFlagAsync(WellKnownFlags.ContainerdStopped);
-                    _logger.LogInformation($"containerd is stopped.");
-                }, CancellationToken.None));
+            if (!await _serviceControl.IsServiceRunning(serviceName))
+            {
+                _logger.LogInformation("containerd service is being started...");
+                await _serviceControl.StartService(serviceName);
+            }
         }
 
         private async Task OnStoppingAsync(IContext context, IAssociatedData? data, CancellationToken cancellationToken)
         {
-            if (OperatingSystem.IsLinux())
-            {
-                // Unmount anything under the RKM root that appears in /etc/mtab, so that it's safe
-                // to delete an RKM install without running into "resource busy".
-                var mounts = await File.ReadAllLinesAsync("/etc/mtab", cancellationToken);
-                foreach (var mount in mounts)
-                {
-                    var mountComponents = mount.Split(' ');
-                    if (mountComponents.Length > 2 && mountComponents[1].StartsWith(_pathProvider.RKMRoot, StringComparison.Ordinal))
-                    {
-                        _logger.LogInformation($"Unmounting container folder due to shutdown: {mountComponents[1]}");
+            var serviceName = OperatingSystem.IsWindows() ? "RKM - Containerd" : "rkm-containerd";
 
-                        var unmount = _processMonitorFactory.CreateTerminatingProcess(new ProcessSpecification(
-                            filename: "/usr/bin/umount",
-                            arguments: new[]
-                            {
-                                mountComponents[1],
-                            },
-                            silent: true));
-                        if ((await unmount.RunAsync(CancellationToken.None)) != 0)
-                        {
-                            _logger.LogWarning($"Unmount operation failed for: {mountComponents[1]}");
-                        }
-                    }
-                }
-
-                _logger.LogInformation($"Unmounted all container folders.");
-            }
-            else if (OperatingSystem.IsWindows())
+            if (await _serviceControl.IsServiceInstalled(serviceName))
             {
-                foreach (var computeSystem in _hcsService!.GetHcsComputeSystems())
-                {
-                    if (computeSystem.SystemType == "Container")
-                    {
-                        _logger.LogInformation($"Killing HCS compute system {computeSystem.Id}...");
-                        _hcsService.TerminateHcsSystem(computeSystem.Id);
-                    }
-                }
+                _logger.LogInformation("containerd service is being stopped...");
+                await _serviceControl.StopService(serviceName);
             }
         }
     }

--- a/UET/Redpoint.KubernetesManager/Components/IComponent.cs
+++ b/UET/Redpoint.KubernetesManager/Components/IComponent.cs
@@ -2,7 +2,7 @@
 {
     using Redpoint.KubernetesManager.Signalling;
 
-    internal interface IComponent
+    public interface IComponent
     {
         void RegisterSignals(IRegistrationContext context);
     }

--- a/UET/Redpoint.KubernetesManager/Components/ManifestServerComponent.cs
+++ b/UET/Redpoint.KubernetesManager/Components/ManifestServerComponent.cs
@@ -1,0 +1,194 @@
+﻿namespace Redpoint.KubernetesManager.Components
+{
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using Redpoint.Concurrency;
+    using Redpoint.KubernetesManager.Manifests;
+    using Redpoint.KubernetesManager.Models;
+    using Redpoint.KubernetesManager.Services;
+    using Redpoint.KubernetesManager.Signalling;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.WebSockets;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class ManifestServerComponent : IComponent, IAsyncDisposable
+    {
+        private CancellationTokenSource? _cts;
+        private Task? _apiTask;
+        private readonly ILogger<ManifestServerComponent> _logger;
+        private readonly IHostApplicationLifetime _hostApplicationLifetime;
+        private readonly IPathProvider _pathProvider;
+        private readonly List<Func<Task>> _manifestNotifications;
+        private ContainerdManifest _currentManifest;
+
+        public ManifestServerComponent(
+            ILogger<ManifestServerComponent> logger,
+            IHostApplicationLifetime hostApplicationLifetime,
+            IPathProvider pathProvider)
+        {
+            _logger = logger;
+            _hostApplicationLifetime = hostApplicationLifetime;
+            _pathProvider = pathProvider;
+            _manifestNotifications = new List<Func<Task>>();
+            _currentManifest = new ContainerdManifest
+            {
+                ContainerdInstallRootPath = Path.Combine(_pathProvider.RKMRoot, "containerd"),
+                ContainerdStatePath = Path.Combine(_pathProvider.RKMRoot, "containerd-state"),
+                ContainerdVersion = "1.6.18",
+                UseRedpointContainerd = true,
+                RuncVersion = "1.3.0",
+                CniPluginsPath = Path.Combine(_pathProvider.RKMRoot, "cni-plugins"),
+            };
+        }
+
+        public void RegisterSignals(IRegistrationContext context)
+        {
+            context.OnSignal(WellKnownSignals.Started, OnStartedAsync);
+            context.OnSignal(WellKnownSignals.Stopping, OnStoppingAsync);
+        }
+
+        private async Task RunAsync()
+        {
+            try
+            {
+                using var listener = new HttpListener();
+                listener.Prefixes.Add($"http://127.0.0.1:8375/");
+                listener.Start();
+                _logger.LogInformation($"Started rkm local manifest server on port 127.0.0.1:8375.");
+
+                while (listener.IsListening && !_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
+                {
+                    var context = await listener.GetContextAsync().AsCancellable(_hostApplicationLifetime.ApplicationStopping);
+
+                    try
+                    {
+                        if (context.Request.Url?.AbsolutePath == "/containerd" &&
+                            context.Request.IsWebSocketRequest)
+                        {
+                            var webSocket = await context.AcceptWebSocketAsync(null);
+
+                            var handler = async () =>
+                            {
+                                _logger.LogInformation("Sending updated manifest for containerd...");
+                                await webSocket.WebSocket.SendAsync(
+                                    Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_currentManifest, ManifestJsonSerializerContext.Default.ContainerdManifest)),
+                                    WebSocketMessageType.Text,
+                                    true,
+                                    CancellationToken.None);
+                            };
+                            _manifestNotifications.Add(handler);
+                            try
+                            {
+                                _logger.LogInformation("Sending initial manifest for containerd...");
+                                await webSocket.WebSocket.SendAsync(
+                                    Encoding.UTF8.GetBytes(JsonSerializer.Serialize(_currentManifest, ManifestJsonSerializerContext.Default.ContainerdManifest)),
+                                    WebSocketMessageType.Text,
+                                    true,
+                                    CancellationToken.None);
+
+                                while (webSocket.WebSocket.State == WebSocketState.Open)
+                                {
+                                    var buffer = new byte[1024];
+                                    await webSocket.WebSocket.ReceiveAsync(buffer, CancellationToken.None);
+                                }
+                            }
+                            finally
+                            {
+                                _manifestNotifications.Remove(handler);
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException) when (_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
+                    {
+                        // Expected.
+                    }
+                    catch (Exception ex)
+                    {
+                        try
+                        {
+                            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                        }
+                        catch { }
+                        _logger.LogError(ex, $"Failed to respond to a containerd manifest request: {ex.Message}");
+                    }
+                    finally
+                    {
+                        context.Response.OutputStream.Close();
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
+            {
+                // Expected.
+            }
+            catch (Exception ex)
+            {
+                _logger.LogCritical(ex, $"rkm local manifest server loop unexpectedly failed, which will cause rkm to shutdown as it will no longer be able to respond to new nodes: {ex.Message}");
+            }
+            finally
+            {
+                if (!_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested &&
+                    !_hostApplicationLifetime.ApplicationStopped.IsCancellationRequested)
+                {
+                    Environment.ExitCode = 1;
+                    _hostApplicationLifetime.StopApplication();
+                }
+            }
+        }
+
+        private Task OnStartedAsync(IContext context, IAssociatedData? data, CancellationToken cancellationToken)
+        {
+            if (_apiTask == null)
+            {
+                _logger.LogInformation("Starting local manifest server...");
+
+                _cts = new CancellationTokenSource();
+                _apiTask = Task.Run(RunAsync, CancellationToken.None);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task OnStoppingAsync(IContext context, IAssociatedData? data, CancellationToken cancellationToken)
+        {
+            if (_apiTask != null && _cts != null)
+            {
+                _logger.LogInformation("Stopping local manifest server...");
+
+                _cts.Cancel();
+                try
+                {
+                    await _apiTask;
+                }
+                catch { }
+                _cts.Dispose();
+                _apiTask = null;
+                _cts = null;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_apiTask != null && _cts != null)
+            {
+                _logger.LogInformation("Stopping local manifest server...");
+
+                _cts.Cancel();
+                try
+                {
+                    await _apiTask;
+                }
+                catch { }
+                _cts.Dispose();
+                _apiTask = null;
+                _cts = null;
+            }
+        }
+    }
+}

--- a/UET/Redpoint.KubernetesManager/IRkmVersionProvider.cs
+++ b/UET/Redpoint.KubernetesManager/IRkmVersionProvider.cs
@@ -9,5 +9,7 @@ namespace Redpoint.KubernetesManager
     public interface IRkmVersionProvider
     {
         string Version { get; }
+
+        string UetFilePath { get; }
     }
 }

--- a/UET/Redpoint.KubernetesManager/KubernetesManagerServiceExtensions.cs
+++ b/UET/Redpoint.KubernetesManager/KubernetesManagerServiceExtensions.cs
@@ -15,18 +15,23 @@ using Redpoint.KubernetesManager.Implementations;
 using Redpoint.Windows.HostNetworkingService;
 using Redpoint.Windows.Firewall;
 using Redpoint.KubernetesManager.Services.Helm;
+using Redpoint.KubernetesManager.Services.Manifest;
 
 namespace Redpoint.KubernetesManager
 {
     public static class KubernetesManagerServiceExtensions
     {
-        public static void AddKubernetesManager(this IServiceCollection services)
+        public static void AddKubernetesManager(this IServiceCollection services, bool withPathProvider)
         {
             // Register shared services.
             services.AddSingleton<IAssetConfiguration, DefaultAssetConfiguration>();
-            services.AddSingleton<IPathProvider, DefaultPathProvider>();
+            if (withPathProvider)
+            {
+                services.AddSingleton<IPathProvider, DefaultPathProvider>();
+                services.AddSingleton<IAssetManager, DefaultAssetManager>();
+                services.AddSingleton<IWslDistro, DefaultWslDistro>();
+            }
             services.AddSingleton<IProcessKiller, DefaultProcessKiller>();
-            services.AddSingleton<IAssetManager, DefaultAssetManager>();
             services.AddSingleton<IWindowsFeatureManager, WindowsFeatureManager>();
             services.AddSingleton<IResourceManager, DefaultResourceManager>();
             services.AddSingleton<ICertificateGenerator, DefaultCertificateGenerator>();
@@ -41,43 +46,49 @@ namespace Redpoint.KubernetesManager
             services.AddSingleton<IControllerApiService, DefaultControllerApiService>();
             services.AddSingleton<INodeManifestClient, DefaultNodeManifestClient>();
             services.AddSingleton<IClusterNetworkingConfiguration, DefaultClusterNetworkingConfiguration>();
-            services.AddSingleton<IWslDistro, DefaultWslDistro>();
             services.AddSingleton<IWslTranslation, DefaultWslTranslation>();
             services.AddSingleton<IRkmGlobalRootProvider, DefaultRkmGlobalRootProvider>();
             services.AddSingleton<IHelmDeployment, DefaultHelmDeployment>();
+            services.AddSingleton<IGenericManifestClient, DefaultGenericManifestClient>();
 
             // Register controller-only components.
-            services.AddSingleton<IComponent, CertificateGeneratingComponent>();
-            services.AddSingleton<IComponent, HelmRKMProvisioningComponent>();
-            services.AddSingleton<IComponent, EncryptionConfigGeneratingComponent>();
-            services.AddSingleton<IComponent, EtcdComponent>();
-            services.AddSingleton<IComponent, KubeConfigGeneratingComponent>();
-            services.AddSingleton<IComponent, KubernetesApiServerComponent>();
-            services.AddSingleton<IComponent, KubernetesClientComponent>();
-            services.AddSingleton<IComponent, KubernetesControllerManagerComponent>();
-            services.AddSingleton<IComponent, KubernetesSchedulerComponent>();
-            services.AddSingleton<IComponent, NodeComponentGuardComponent>();
-            services.AddSingleton<IComponent, RKMApiServiceStartingComponent>();
+            if (withPathProvider)
+            {
+                services.AddSingleton<IComponent, CertificateGeneratingComponent>();
+                services.AddSingleton<IComponent, HelmRKMProvisioningComponent>();
+                services.AddSingleton<IComponent, EncryptionConfigGeneratingComponent>();
+                services.AddSingleton<IComponent, EtcdComponent>();
+                services.AddSingleton<IComponent, KubeConfigGeneratingComponent>();
+                services.AddSingleton<IComponent, KubernetesApiServerComponent>();
+                services.AddSingleton<IComponent, KubernetesClientComponent>();
+                services.AddSingleton<IComponent, KubernetesControllerManagerComponent>();
+                services.AddSingleton<IComponent, KubernetesSchedulerComponent>();
+                services.AddSingleton<IComponent, NodeComponentGuardComponent>();
+                services.AddSingleton<IComponent, RKMApiServiceStartingComponent>();
 
-            // Register node-only components.
-            services.AddSingleton<IComponent, NodeManifestExpanderComponent>();
+                // Register node-only components.
+                services.AddSingleton<IComponent, NodeManifestExpanderComponent>();
 
-            // Register WSL "extra" components.
-            services.AddSingleton<IComponent, WslContainerdComponent>();
-            services.AddSingleton<IComponent, WslKubeletComponent>();
-            services.AddSingleton<IComponent, WslKubeProxyComponent>();
-            services.AddSingleton<IComponent, CoreDNSComponent>();
+                // Register WSL "extra" components.
+                services.AddSingleton<IComponent, WslContainerdComponent>();
+                services.AddSingleton<IComponent, WslKubeletComponent>();
+                services.AddSingleton<IComponent, WslKubeProxyComponent>();
+                services.AddSingleton<IComponent, CoreDNSComponent>();
 
-            // Register shared components.
-            services.AddSingleton<IComponent, AssetPreparationComponent>();
-            services.AddSingleton<IComponent, ContainerdComponent>();
-            services.AddSingleton<IComponent, KubeletComponent>();
-            services.AddSingleton<IComponent, NetworkingConfigurationComponent>();
+                // Register shared components.
+                services.AddSingleton<IComponent, AssetPreparationComponent>();
+                services.AddSingleton<IComponent, ContainerdComponent>();
+                services.AddSingleton<IComponent, KubeletComponent>();
+                services.AddSingleton<IComponent, NetworkingConfigurationComponent>();
+            }
 
             // Register platform-specific components.
             if (OperatingSystem.IsWindows())
             {
-                services.AddSingleton<IComponent, WindowsPreflightComponent>();
+                if (withPathProvider)
+                {
+                    services.AddSingleton<IComponent, WindowsPreflightComponent>();
+                }
                 services.AddSingleton(_ =>
                 {
                     if (OperatingSystem.IsWindows())
@@ -105,7 +116,10 @@ namespace Redpoint.KubernetesManager
             }
             else if (OperatingSystem.IsLinux())
             {
-                services.AddSingleton<IComponent, SwapDisablingComponent>();
+                if (withPathProvider)
+                {
+                    services.AddSingleton<IComponent, SwapDisablingComponent>();
+                }
                 services.AddSingleton<INetworkingConfiguration, LinuxNetworkingConfiguration>();
             }
             else
@@ -113,12 +127,14 @@ namespace Redpoint.KubernetesManager
                 throw new PlatformNotSupportedException();
             }
 
-            // Register command line arguments.
-            services.AddSingleton<RKMCommandLineArguments>();
+            if (withPathProvider)
+            {
+                // Register command line arguments.
+                services.AddSingleton<RKMCommandLineArguments>();
 
-            // Register the main worker which executes components.
-            services.AddSingleton<IComponent[]>(sp => sp.GetServices<IComponent>().ToArray());
-            services.AddHostedService<RKMWorker>();
+                // Register the main worker which executes components.
+                services.AddSingleton<IComponent[]>(sp => sp.GetServices<IComponent>().ToArray());
+            }
         }
     }
 }

--- a/UET/Redpoint.KubernetesManager/KubernetesManagerServiceExtensions.cs
+++ b/UET/Redpoint.KubernetesManager/KubernetesManagerServiceExtensions.cs
@@ -78,6 +78,7 @@ namespace Redpoint.KubernetesManager
                 // Register shared components.
                 services.AddSingleton<IComponent, AssetPreparationComponent>();
                 services.AddSingleton<IComponent, ContainerdComponent>();
+                services.AddSingleton<IComponent, ManifestServerComponent>();
                 services.AddSingleton<IComponent, KubeletComponent>();
                 services.AddSingleton<IComponent, NetworkingConfigurationComponent>();
             }

--- a/UET/Redpoint.KubernetesManager/Manifests/ContainerdManifest.cs
+++ b/UET/Redpoint.KubernetesManager/Manifests/ContainerdManifest.cs
@@ -1,0 +1,48 @@
+﻿namespace Redpoint.KubernetesManager.Manifests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+
+    public class ContainerdManifest
+    {
+        /// <summary>
+        /// The directory under which one or more versions of containerd will be installed.
+        /// </summary>
+        [JsonPropertyName("containerdInstallRootPath")]
+        public required string ContainerdInstallRootPath { get; set; }
+
+        /// <summary>
+        /// The directory where containerd should store all of it's state and configuration.
+        /// </summary>
+        [JsonPropertyName("containerdStatePath")]
+        public required string ContainerdStatePath { get; set; }
+
+        /// <summary>
+        /// The containerd version to install.
+        /// </summary>
+        [JsonPropertyName("containerdVersion")]
+        public required string ContainerdVersion { get; set; }
+
+        /// <summary>
+        /// If true, the patched version of containerd built by Redpoint will be used instead of the upstream version.
+        /// </summary>
+        [JsonPropertyName("useRedpointContainerd")]
+        public required bool UseRedpointContainerd { get; set; }
+
+        /// <summary>
+        /// The runc version to install.
+        /// </summary>
+        [JsonPropertyName("runcVersion")]
+        public required string RuncVersion { get; set; }
+
+        /// <summary>
+        /// The directory where CNI plugin binaries are installed.
+        /// </summary>
+        [JsonPropertyName("cniPluginsPath")]
+        public required string CniPluginsPath { get; set; }
+    }
+}

--- a/UET/Redpoint.KubernetesManager/Manifests/ManifestJsonSerializerContext.cs
+++ b/UET/Redpoint.KubernetesManager/Manifests/ManifestJsonSerializerContext.cs
@@ -1,0 +1,9 @@
+﻿namespace Redpoint.KubernetesManager.Manifests
+{
+    using System.Text.Json.Serialization;
+
+    [JsonSerializable(typeof(ContainerdManifest))]
+    public partial class ManifestJsonSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/UET/Redpoint.KubernetesManager/Models/Hcs/HcsComputeSystem.cs
+++ b/UET/Redpoint.KubernetesManager/Models/Hcs/HcsComputeSystem.cs
@@ -2,7 +2,7 @@
 {
     using System.Text.Json.Serialization;
 
-    internal class HcsComputeSystem
+    public class HcsComputeSystem
     {
         [JsonPropertyName("SystemType")]
         public string SystemType { get; set; } = string.Empty;

--- a/UET/Redpoint.KubernetesManager/Models/Hcs/HcsComputeSystemWithId.cs
+++ b/UET/Redpoint.KubernetesManager/Models/Hcs/HcsComputeSystemWithId.cs
@@ -2,7 +2,7 @@
 {
     using System.Text.Json.Serialization;
 
-    internal class HcsComputeSystemWithId : HcsComputeSystem
+    public class HcsComputeSystemWithId : HcsComputeSystem
     {
         [JsonPropertyName("Id")]
         public string Id { get; set; } = string.Empty;

--- a/UET/Redpoint.KubernetesManager/Models/NodeManifest.cs
+++ b/UET/Redpoint.KubernetesManager/Models/NodeManifest.cs
@@ -2,7 +2,7 @@
 {
     using System.Text.Json.Serialization;
 
-    internal class NodeManifest
+    public class NodeManifest
     {
         /// <summary>
         /// Flannel is annoying and requires that the path it emits the flannel CNI plugin to be the same

--- a/UET/Redpoint.KubernetesManager/Models/ProcessSpecification.cs
+++ b/UET/Redpoint.KubernetesManager/Models/ProcessSpecification.cs
@@ -1,6 +1,8 @@
 ﻿namespace Redpoint.KubernetesManager.Models
 {
-    internal class ProcessSpecification
+    using System.Diagnostics.CodeAnalysis;
+
+    public class ProcessSpecification
     {
         public ProcessSpecification(
             string filename,
@@ -22,6 +24,7 @@
 
         public string Filename { get; }
 
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "This is legacy code.")]
         public string[] Arguments { get; }
 
         public Dictionary<string, string>? Environment { get; }

--- a/UET/Redpoint.KubernetesManager/RKMCommandLineArguments.cs
+++ b/UET/Redpoint.KubernetesManager/RKMCommandLineArguments.cs
@@ -2,11 +2,13 @@
 {
     using Redpoint.KubernetesManager.Services;
     using Redpoint.Uet.Configuration;
+    using System.Diagnostics.CodeAnalysis;
 
-    internal class RKMCommandLineArguments
+    public class RKMCommandLineArguments
     {
         private Lazy<string[]> _args;
 
+        [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "")]
         public string[] Arguments => _args.Value;
 
         public RKMCommandLineArguments(

--- a/UET/Redpoint.KubernetesManager/RKMWorker.cs
+++ b/UET/Redpoint.KubernetesManager/RKMWorker.cs
@@ -20,7 +20,7 @@ namespace Redpoint.KubernetesManager
         private readonly RKMCommandLineArguments _commandLine;
         private readonly IProcessKiller _processKiller;
 
-        internal RKMWorker(
+        public RKMWorker(
             ILogger<RKMWorker> logger,
             ILogger<Executor> executorLogger,
             IPathProvider pathProvider,

--- a/UET/Redpoint.KubernetesManager/RKMWorker.cs
+++ b/UET/Redpoint.KubernetesManager/RKMWorker.cs
@@ -8,7 +8,7 @@ using System.Net;
 
 namespace Redpoint.KubernetesManager
 {
-    internal class RKMWorker : BackgroundService
+    public class RKMWorker : BackgroundService
     {
         private readonly ILogger<RKMWorker> _logger;
         private readonly ILogger<Executor> _executorLogger;
@@ -20,7 +20,7 @@ namespace Redpoint.KubernetesManager
         private readonly RKMCommandLineArguments _commandLine;
         private readonly IProcessKiller _processKiller;
 
-        public RKMWorker(
+        internal RKMWorker(
             ILogger<RKMWorker> logger,
             ILogger<Executor> executorLogger,
             IPathProvider pathProvider,

--- a/UET/Redpoint.KubernetesManager/Services/DefaultProcessKiller.cs
+++ b/UET/Redpoint.KubernetesManager/Services/DefaultProcessKiller.cs
@@ -9,13 +9,13 @@
     internal class DefaultProcessKiller : IProcessKiller
     {
         private readonly ILogger<DefaultProcessKiller> _logger;
-        private readonly IPathProvider _pathProvider;
+        private readonly IPathProvider? _pathProvider;
         private readonly IWslDistro? _wslDistro;
         private readonly IWindowsHcsService? _hcsService;
 
         public DefaultProcessKiller(
             ILogger<DefaultProcessKiller> logger,
-            IPathProvider pathProvider,
+            IPathProvider? pathProvider = null,
             IWslDistro? wslDistro = null,
             IWindowsHcsService? hcsService = null)
         {
@@ -70,7 +70,7 @@
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            if (OperatingSystem.IsWindows())
+            if (OperatingSystem.IsWindows() && _pathProvider != null)
             {
                 if (File.Exists(_wslDistro!.WslPath))
                 {

--- a/UET/Redpoint.KubernetesManager/Services/DefaultProcessKiller.cs
+++ b/UET/Redpoint.KubernetesManager/Services/DefaultProcessKiller.cs
@@ -28,8 +28,6 @@
         public async Task EnsureProcessesAreNotRunning(CancellationToken cancellationToken)
         {
             await EnsureProcessesAreNotRunning([
-                "containerd",
-                "containerd-shim-runhcs-v1",
                 "flanneld",
                 "kubelet",
                 "kube-proxy",
@@ -40,7 +38,7 @@
             ], cancellationToken);
         }
 
-        private async Task EnsureProcessesAreNotRunning(string[] processNames, CancellationToken cancellationToken)
+        public async Task EnsureProcessesAreNotRunning(string[] processNames, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Ensuring existing Kubernetes processes are not running...");
             foreach (var processName in processNames)

--- a/UET/Redpoint.KubernetesManager/Services/IControllerAutodiscoveryService.cs
+++ b/UET/Redpoint.KubernetesManager/Services/IControllerAutodiscoveryService.cs
@@ -2,7 +2,7 @@
 {
     using System.Threading.Tasks;
 
-    internal interface IControllerAutodiscoveryService
+    public interface IControllerAutodiscoveryService
     {
         Task<string?> AttemptAutodiscoveryOfController(CancellationToken stoppingToken);
 

--- a/UET/Redpoint.KubernetesManager/Services/INodeManifestClient.cs
+++ b/UET/Redpoint.KubernetesManager/Services/INodeManifestClient.cs
@@ -4,7 +4,7 @@
     using System.Net;
     using System.Threading.Tasks;
 
-    internal interface INodeManifestClient
+    public interface INodeManifestClient
     {
         Task<NodeManifest> ObtainNodeManifestAsync(IPAddress controllerAddress, string nodeName, CancellationToken stoppingToken);
     }

--- a/UET/Redpoint.KubernetesManager/Services/IProcessKiller.cs
+++ b/UET/Redpoint.KubernetesManager/Services/IProcessKiller.cs
@@ -1,7 +1,9 @@
 ﻿namespace Redpoint.KubernetesManager.Services
 {
-    internal interface IProcessKiller
+    public interface IProcessKiller
     {
         Task EnsureProcessesAreNotRunning(CancellationToken cancellationToken);
+
+        Task EnsureProcessesAreNotRunning(string[] processNames, CancellationToken cancellationToken);
     }
 }

--- a/UET/Redpoint.KubernetesManager/Services/IProcessMonitorFactory.cs
+++ b/UET/Redpoint.KubernetesManager/Services/IProcessMonitorFactory.cs
@@ -2,13 +2,13 @@
 {
     using Redpoint.KubernetesManager.Models;
 
-    internal interface IProcessMonitorFactory
+    public interface IProcessMonitor
     {
-        internal interface IProcessMonitor
-        {
-            Task<int> RunAsync(CancellationToken cancellationToken);
-        }
+        Task<int> RunAsync(CancellationToken cancellationToken);
+    }
 
+    public interface IProcessMonitorFactory
+    {
         [Obsolete("Use ProcessSpecification instead.")]
         IProcessMonitor CreatePerpetualProcess(string filename, string[] arguments, Dictionary<string, string>? environment, Func<CancellationToken, Task>? beforeStart = null, Func<CancellationToken, Task>? afterStart = null);
 

--- a/UET/Redpoint.KubernetesManager/Services/Manifest/DefaultGenericManifestClient.cs
+++ b/UET/Redpoint.KubernetesManager/Services/Manifest/DefaultGenericManifestClient.cs
@@ -1,0 +1,334 @@
+﻿namespace Redpoint.KubernetesManager.Services.Manifest
+{
+    using Microsoft.Extensions.Logging;
+    using Redpoint.Concurrency;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.WebSockets;
+    using System.Text;
+    using System.Text.Json;
+    using System.Text.Json.Serialization.Metadata;
+    using System.Threading.Tasks;
+
+    public class DefaultGenericManifestClient : IGenericManifestClient
+    {
+        private readonly ILogger<DefaultGenericManifestClient> _logger;
+
+        public DefaultGenericManifestClient(
+            ILogger<DefaultGenericManifestClient> logger)
+        {
+            _logger = logger;
+        }
+
+        private async Task PollManifestAsync<T>(
+            Uri uri,
+            string? manifestCachePath,
+            JsonTypeInfo<T> jsonTypeInfo,
+            Func<T, long, CancellationToken, Task> manifestReceived,
+            CancellationToken cancellationToken)
+        {
+            var buffer = new byte[16 * 1024];
+            var gotInitialManifest = false;
+
+            if (manifestCachePath != null && File.Exists(manifestCachePath))
+            {
+                try
+                {
+                    var manifestContent = File.ReadAllText(manifestCachePath, Encoding.UTF8);
+                    var manifest = JsonSerializer.Deserialize<T>(
+                        manifestContent,
+                        jsonTypeInfo);
+                    if (manifest == null)
+                    {
+                        _logger.LogWarning("Manifest in cache file was deserialized to a null value and ignored.");
+                    }
+                    else
+                    {
+                        await manifestReceived(
+                            manifest,
+                            Hashing.Hash.XxHash64(manifestContent, Encoding.UTF8).Hash,
+                            cancellationToken);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, $"Unable to read manifest from cache file: {manifestCachePath}");
+                }
+            }
+
+        retryInitialConnection:
+            // Establish an initial connection.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            ClientWebSocket webSocketClient;
+            try
+            {
+                webSocketClient = new ClientWebSocket();
+                await webSocketClient.ConnectAsync(uri, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (WebSocketException ex)
+            {
+                _logger.LogWarning($"Failed to connect to WebSocket ({ex.WebSocketErrorCode}).");
+                await Task.Delay(10000, cancellationToken);
+                goto retryInitialConnection;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, $"Failed to connect to WebSocket: {ex.Message}");
+                await Task.Delay(10000, cancellationToken);
+                goto retryInitialConnection;
+            }
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Try to get the manifest.
+                WebSocketReceiveResult result;
+                try
+                {
+                    result = await webSocketClient.ReceiveAsync(buffer, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, $"Failed to receive message from WebSocket: {ex.Message}");
+                    await Task.Delay(10000, cancellationToken);
+                    if (webSocketClient.State != WebSocketState.Open)
+                    {
+                        // WebSocket no longer open, we have to retry the whole connection.
+                        goto retryInitialConnection;
+                    }
+                    else
+                    {
+                        // Try to get a message again.
+                        if (gotInitialManifest)
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            await webSocketClient
+                                .CloseAsync(WebSocketCloseStatus.InvalidMessageType, null, cancellationToken)
+                                .ConfigureAwait(false);
+                            goto retryInitialConnection;
+                        }
+                    }
+                }
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    // WebSocket has closed; attempt to re-establish connection.
+                    goto retryInitialConnection;
+                }
+
+                if (result.MessageType == WebSocketMessageType.Binary)
+                {
+                    // Message isn't a type we handle.
+                    _logger.LogWarning("WebSocket sent a binary message, which is not expected for manifest monitoring.");
+                    if (gotInitialManifest)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        await webSocketClient
+                            .CloseAsync(WebSocketCloseStatus.InvalidMessageType, null, cancellationToken)
+                            .ConfigureAwait(false);
+                        goto retryInitialConnection;
+                    }
+                }
+
+                try
+                {
+                    var manifestContent = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                    if (manifestCachePath != null)
+                    {
+                        var manifestCacheDirectoryPath = Path.GetDirectoryName(manifestCachePath);
+                        if (manifestCacheDirectoryPath != null)
+                        {
+                            Directory.CreateDirectory(manifestCacheDirectoryPath);
+                        }
+                        await File.WriteAllTextAsync(
+                            manifestCachePath,
+                            manifestContent,
+                            cancellationToken);
+                    }
+
+                    var manifest = JsonSerializer.Deserialize<T>(manifestContent, jsonTypeInfo);
+                    if (manifest == null)
+                    {
+                        _logger.LogWarning("Received manifest deserialized to a null value.");
+                        continue;
+                    }
+                    gotInitialManifest = true;
+                    await manifestReceived(
+                        manifest,
+                        Hashing.Hash.XxHash64(manifestContent, Encoding.UTF8).Hash,
+                        cancellationToken);
+
+                    // Now we'll continue through the loop and try to get another update.
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, $"Failed to deserialize manifest from WebSocket: {ex.Message}");
+                    if (gotInitialManifest)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        await webSocketClient
+                            .CloseAsync(WebSocketCloseStatus.InvalidMessageType, null, cancellationToken)
+                            .ConfigureAwait(false);
+                        goto retryInitialConnection;
+                    }
+                }
+            }
+        }
+
+        private class ExecutionState<T> where T : class
+        {
+            public CancellationTokenSource? CurrentExecutingCancellationTokenSource;
+
+            public readonly Gate WaitingOnInitialManifest = new Gate();
+
+            public Task? PollingTask;
+
+            public Task? ExecutingTask;
+
+            public long PreviousHash;
+        }
+
+        public async Task RegisterAndRunWithManifestAsync<T>(
+            Uri uri,
+            string? manifestCachePath,
+            JsonTypeInfo<T> jsonTypeInfo,
+            Func<T, CancellationToken, Task> runWithManifest,
+            CancellationToken cancellationToken) where T : class
+        {
+            var state = new ExecutionState<T>();
+
+            // Handle new manifests when they arrive.
+            var manifestArrived = async (T newManifest, long newHash, CancellationToken _) =>
+            {
+                // If we are already executing a task, and the hash is the same, don't do anything.
+                if (state.ExecutingTask != null && state.PreviousHash == newHash)
+                {
+                    _logger.LogInformation("Ignoring new manifest update as it has the same hash as the previous manifest.");
+                }
+
+                // Tell the executing task to cancel it's work via the CTS if there is one.
+                if (state.CurrentExecutingCancellationTokenSource != null)
+                {
+                    state.CurrentExecutingCancellationTokenSource.Cancel();
+                }
+
+                // Wait for the executing task to stop if there is one.
+                if (state.ExecutingTask != null)
+                {
+                    try
+                    {
+                        await state.ExecutingTask;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, $"Unexpected exception from executing task during manifest update handling: {ex.Message}");
+                    }
+                }
+
+                // Dispose the existing CTS if there is one.
+                if (state.CurrentExecutingCancellationTokenSource != null)
+                {
+                    state.CurrentExecutingCancellationTokenSource.Dispose();
+                }
+
+                // Create a new CTS for starting our new task.
+                state.CurrentExecutingCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                // Execute the task in the background.
+                var executingCancellationToken = state.CurrentExecutingCancellationTokenSource.Token;
+                state.PreviousHash = newHash;
+                state.ExecutingTask = Task.Run(async () => await runWithManifest(newManifest, executingCancellationToken), executingCancellationToken);
+            };
+
+            // Create our background task that will poll for manifest updates.
+            state.PollingTask = Task.Run(
+                async () => await PollManifestAsync(
+                    uri,
+                    manifestCachePath,
+                    jsonTypeInfo,
+                    manifestArrived,
+                    cancellationToken),
+                cancellationToken);
+
+            // Wait for the cancellation token to be cancelled.
+            try
+            {
+                while (true)
+                {
+                    await Task.Delay(-1, cancellationToken);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+
+            // Wait for the polling task to be done.
+            try
+            {
+                await state.PollingTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, $"Unexpected exception from polling task during shutdown: {ex.Message}");
+            }
+
+            // Tell the executing task to cancel it's work via the CTS if there is one.
+            if (state.CurrentExecutingCancellationTokenSource != null)
+            {
+                state.CurrentExecutingCancellationTokenSource.Cancel();
+            }
+
+            // If there is an executing task, wait for that to be done.
+            if (state.ExecutingTask != null)
+            {
+                try
+                {
+                    await state.ExecutingTask;
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, $"Unexpected exception from executing task during shutdown: {ex.Message}");
+                }
+            }
+
+            // Dispose the existing CTS if there is one.
+            if (state.CurrentExecutingCancellationTokenSource != null)
+            {
+                state.CurrentExecutingCancellationTokenSource.Dispose();
+            }
+        }
+    }
+}

--- a/UET/Redpoint.KubernetesManager/Services/Manifest/IGenericManifestClient.cs
+++ b/UET/Redpoint.KubernetesManager/Services/Manifest/IGenericManifestClient.cs
@@ -1,0 +1,16 @@
+﻿namespace Redpoint.KubernetesManager.Services.Manifest
+{
+    using System;
+    using System.Text.Json.Serialization.Metadata;
+    using System.Threading.Tasks;
+
+    public interface IGenericManifestClient
+    {
+        Task RegisterAndRunWithManifestAsync<T>(
+            Uri uri,
+            string? manifestCachePath,
+            JsonTypeInfo<T> jsonTypeInfo,
+            Func<T, CancellationToken, Task> runWithManifest,
+            CancellationToken cancellationToken) where T : class;
+    }
+}

--- a/UET/Redpoint.KubernetesManager/Services/Windows/IWindowsHcsService.cs
+++ b/UET/Redpoint.KubernetesManager/Services/Windows/IWindowsHcsService.cs
@@ -4,7 +4,7 @@
     using System.Runtime.Versioning;
 
     [SupportedOSPlatform("windows")]
-    internal interface IWindowsHcsService
+    public interface IWindowsHcsService
     {
         HcsComputeSystemWithId[] GetHcsComputeSystems();
 

--- a/UET/Redpoint.KubernetesManager/Services/Windows/WindowsNetworkingConfiguration.cs
+++ b/UET/Redpoint.KubernetesManager/Services/Windows/WindowsNetworkingConfiguration.cs
@@ -233,6 +233,7 @@
             // CNI configuration is no longer written out here; instead it is set up as part of
             // 'startup_script.ps1' in the 'calico-windows-node-scripts' in the Helm chart.
 
+#if FALSE
             // Create an overlay network to trigger vSwitch creation because we need
             // a vSwitch for networking to work. We only do this once because it will
             // disrupt networking.
@@ -300,6 +301,7 @@
                     }
                 }
             }
+#endif
 
             // Only on Windows controllers do we run a kubelet inside WSL. On normal Windows nodes, we only run Windows containers.
             if (isController)

--- a/UET/Redpoint.KubernetesManager/Signalling/Executor.cs
+++ b/UET/Redpoint.KubernetesManager/Signalling/Executor.cs
@@ -6,11 +6,12 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
-    internal class Executor
+    public class Executor
     {
         private readonly ILogger<Executor> _logger;
         private readonly IHostApplicationLifetime _hostApplicationLifetime;
@@ -116,6 +117,7 @@
             }
         }
 
+        [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "")]
         public void RegisterComponents(IComponent[] components)
         {
             foreach (var component in components)

--- a/UET/Redpoint.KubernetesManager/Signalling/IAssociatedData.cs
+++ b/UET/Redpoint.KubernetesManager/Signalling/IAssociatedData.cs
@@ -1,6 +1,9 @@
 ﻿namespace Redpoint.KubernetesManager.Signalling
 {
-    internal interface IAssociatedData
+    using System.Diagnostics.CodeAnalysis;
+
+    [SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "")]
+    public interface IAssociatedData
     {
     }
 }

--- a/UET/Redpoint.KubernetesManager/Signalling/IContext.cs
+++ b/UET/Redpoint.KubernetesManager/Signalling/IContext.cs
@@ -1,8 +1,9 @@
 ﻿namespace Redpoint.KubernetesManager.Signalling
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
 
-    internal interface IContext
+    public interface IContext
     {
         /// <summary>
         /// Sets a flag with the associated data, which other components may be waiting on.
@@ -41,6 +42,7 @@
         /// </summary>
         /// <param name="name">The signal name from <see cref="WellKnownSignals"/>.</param>
         /// <param name="data">The associated data (if any).</param>
+        [SuppressMessage("Design", "CA1030:Use events where appropriate", Justification = "")]
         Task RaiseSignalAsync(string name, IAssociatedData? data, CancellationToken cancellationToken);
 
         /// <summary>

--- a/UET/Redpoint.KubernetesManager/Signalling/IRegistrationContext.cs
+++ b/UET/Redpoint.KubernetesManager/Signalling/IRegistrationContext.cs
@@ -1,10 +1,12 @@
 ﻿namespace Redpoint.KubernetesManager.Signalling
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
 
-    internal delegate Task SignalDelegate(IContext context, IAssociatedData? data, CancellationToken cancellationToken);
+    [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "")]
+    public delegate Task SignalDelegate(IContext context, IAssociatedData? data, CancellationToken cancellationToken);
 
-    internal interface IRegistrationContext
+    public interface IRegistrationContext
     {
         void OnSignal(string signalType, SignalDelegate callback);
 

--- a/UET/Redpoint.KubernetesManager/Signalling/RoleType.cs
+++ b/UET/Redpoint.KubernetesManager/Signalling/RoleType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Redpoint.KubernetesManager.Signalling
 {
-    internal enum RoleType
+    public enum RoleType
     {
         /// <summary>
         /// This instance will run the controller (and optionally a node).

--- a/UET/Redpoint.ServiceControl/IServiceControl.cs
+++ b/UET/Redpoint.ServiceControl/IServiceControl.cs
@@ -41,8 +41,8 @@
         /// <summary>
         /// Installs or updates the service with the given name.
         /// </summary>
-        /// <param name="name">The service name.</param>
-        /// <param name="description">The description of the service.</param>
+        /// <param name="name">The programmatic service name.</param>
+        /// <param name="displayName">The display name of the service.</param>
         /// <param name="executableAndArguments">The executable and arguments to launch.</param>
         /// <param name="stdoutLogPath">On macOS, sets the path to the standard output log file.</param>
         /// <param name="stderrLogPath">On macOS, sets the path to the standard error log file.</param>
@@ -50,7 +50,7 @@
         /// <returns>The awaitable task.</returns>
         Task InstallService(
             string name,
-            string description,
+            string displayName,
             string executableAndArguments,
             string? stdoutLogPath = null,
             string? stderrLogPath = null,

--- a/UET/Redpoint.ServiceControl/IServiceControl.cs
+++ b/UET/Redpoint.ServiceControl/IServiceControl.cs
@@ -46,13 +46,15 @@
         /// <param name="executableAndArguments">The executable and arguments to launch.</param>
         /// <param name="stdoutLogPath">On macOS, sets the path to the standard output log file.</param>
         /// <param name="stderrLogPath">On macOS, sets the path to the standard error log file.</param>
+        /// <param name="manualStart">If true, the service won't be automatically started at computer startup.</param>
         /// <returns>The awaitable task.</returns>
         Task InstallService(
             string name,
             string description,
             string executableAndArguments,
             string? stdoutLogPath = null,
-            string? stderrLogPath = null);
+            string? stderrLogPath = null,
+            bool manualStart = false);
 
         /// <summary>
         /// Uninstalls the service.
@@ -74,6 +76,17 @@
         /// <param name="name">The service name.</param>
         /// <returns>The awaitable task.</returns>
         Task StopService(string name);
-    }
 
+        /// <summary>
+        /// Streams logs for the service.
+        /// </summary>
+        /// <param name="name">The service name.</param>
+        /// <param name="receiveLog">Called when a log entry is received.</param>
+        /// <param name="cancellationToken">The cancellation token that can be used to cancel streaming.</param>
+        /// <returns>The awaitable task.</returns>
+        Task StreamLogsUntilCancelledAsync(
+            string name,
+            Action<ServiceLogLevel, string> receiveLog,
+            CancellationToken cancellationToken);
+    }
 }

--- a/UET/Redpoint.ServiceControl/LinuxServiceControl.cs
+++ b/UET/Redpoint.ServiceControl/LinuxServiceControl.cs
@@ -59,7 +59,7 @@
 
         public async Task InstallService(
             string name,
-            string description,
+            string displayName,
             string executableAndArguments,
             string? stdoutLogPath,
             string? stderrLogPath,
@@ -67,7 +67,7 @@
         {
             await File.WriteAllTextAsync($"/etc/systemd/system/{name}.service", @$"
 [Unit]
-Description={description}
+Description={displayName}
 
 [Service]
 ExecStart={executableAndArguments}

--- a/UET/Redpoint.ServiceControl/MacServiceControl.cs
+++ b/UET/Redpoint.ServiceControl/MacServiceControl.cs
@@ -90,7 +90,7 @@
 
         public async Task InstallService(
             string name,
-            string description,
+            string displayName,
             string executableAndArguments,
             string? stdoutLogPath,
             string? stderrLogPath,
@@ -110,9 +110,9 @@
                 await writer.WriteStartElementAsync(null, "dict", null).ConfigureAwait(false);
 
                 await writer.WriteElementStringAsync(null, "key", null, "Label").ConfigureAwait(false);
-                await writer.WriteElementStringAsync(null, "string", null, name).ConfigureAwait(false);
+                await writer.WriteElementStringAsync(null, "string", null, displayName).ConfigureAwait(false);
                 await writer.WriteElementStringAsync(null, "key", null, "ServiceDescription").ConfigureAwait(false);
-                await writer.WriteElementStringAsync(null, "string", null, description).ConfigureAwait(false);
+                await writer.WriteElementStringAsync(null, "string", null, displayName).ConfigureAwait(false);
 
                 await writer.WriteElementStringAsync(null, "key", null, "IsManagedByRedpointServiceControl").ConfigureAwait(false);
                 await writer.WriteStartElementAsync(null, "true", null).ConfigureAwait(false);

--- a/UET/Redpoint.ServiceControl/MacServiceControl.cs
+++ b/UET/Redpoint.ServiceControl/MacServiceControl.cs
@@ -88,7 +88,13 @@
             }
         }
 
-        public async Task InstallService(string name, string description, string executableAndArguments, string? stdoutLogPath, string? stderrLogPath)
+        public async Task InstallService(
+            string name,
+            string description,
+            string executableAndArguments,
+            string? stdoutLogPath,
+            string? stderrLogPath,
+            bool manualStart)
         {
             using (var writer = XmlWriter.Create(
                 $"/Library/LaunchDaemons/{name}.plist",
@@ -113,7 +119,14 @@
                 await writer.WriteEndElementAsync().ConfigureAwait(false);
 
                 await writer.WriteElementStringAsync(null, "key", null, "RunAtLoad").ConfigureAwait(false);
-                await writer.WriteStartElementAsync(null, "true", null).ConfigureAwait(false);
+                if (manualStart)
+                {
+                    await writer.WriteStartElementAsync(null, "true", null).ConfigureAwait(false);
+                }
+                else
+                {
+                    await writer.WriteStartElementAsync(null, "false", null).ConfigureAwait(false);
+                }
                 await writer.WriteEndElementAsync().ConfigureAwait(false);
 
                 await writer.WriteElementStringAsync(null, "key", null, "KeepAlive").ConfigureAwait(false);
@@ -267,6 +280,14 @@
             })!.WaitForExitAsync().ConfigureAwait(false);
 
             File.Delete($"/Library/LaunchDaemons/{name}.plist");
+        }
+
+        public Task StreamLogsUntilCancelledAsync(
+            string name,
+            Action<ServiceLogLevel, string> receiveLog,
+            CancellationToken cancellationToken)
+        {
+            throw new PlatformNotSupportedException("StreamLogsUntilCancelledAsync is not yet supported on macOS");
         }
     }
 }

--- a/UET/Redpoint.ServiceControl/Redpoint.ServiceControl.csproj
+++ b/UET/Redpoint.ServiceControl/Redpoint.ServiceControl.csproj
@@ -4,6 +4,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="System.Diagnostics.EventLog" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Redpoint.ProcessExecution\Redpoint.ProcessExecution.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../Lib/LibraryPackaging.Build.props" />

--- a/UET/Redpoint.ServiceControl/ServiceLogLevel.cs
+++ b/UET/Redpoint.ServiceControl/ServiceLogLevel.cs
@@ -1,0 +1,9 @@
+﻿namespace Redpoint.ServiceControl
+{
+    public enum ServiceLogLevel
+    {
+        Information,
+        Warning,
+        Error,
+    }
+}

--- a/UET/UET.sln
+++ b/UET/UET.sln
@@ -358,6 +358,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.Windows.HostNetwor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.Windows.Firewall", "Redpoint.Windows.Firewall\Redpoint.Windows.Firewall.csproj", "{29BA4DF0-B40E-4B27-8C2A-4F622F0B181A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.KubernetesManager.Tests", "Redpoint.KubernetesManager.Tests\Redpoint.KubernetesManager.Tests.csproj", "{F326BD9A-A701-4408-B32A-AA89A5FF3380}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -972,6 +974,10 @@ Global
 		{29BA4DF0-B40E-4B27-8C2A-4F622F0B181A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29BA4DF0-B40E-4B27-8C2A-4F622F0B181A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29BA4DF0-B40E-4B27-8C2A-4F622F0B181A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F326BD9A-A701-4408-B32A-AA89A5FF3380}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F326BD9A-A701-4408-B32A-AA89A5FF3380}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F326BD9A-A701-4408-B32A-AA89A5FF3380}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F326BD9A-A701-4408-B32A-AA89A5FF3380}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UET/uet/Commands/Cluster/ClusterCommand.cs
+++ b/UET/uet/Commands/Cluster/ClusterCommand.cs
@@ -56,6 +56,7 @@ namespace UET.Commands.Cluster
             {
                 command.AddCommand(ClusterGetHnsEndpointCommand.CreateClusterGetHnsEndpointCommand());
             }
+            command.AddCommand(ClusterRunContainerdCommand.CreateRunContainerdCommand());
             return command;
         }
     }

--- a/UET/uet/Commands/Cluster/ClusterRunContainerdCommand.cs
+++ b/UET/uet/Commands/Cluster/ClusterRunContainerdCommand.cs
@@ -41,10 +41,10 @@
                     {
                         services.AddWindowsService(options =>
                         {
-                            options.ServiceName = "RKM - Containerd";
+                            options.ServiceName = "rkm-containerd";
                         });
                     }
-                    services.AddRkmServiceHelpers(false);
+                    services.AddRkmServiceHelpers(false, "rkm-containerd");
                     services.AddHostedService<ContainerdHostedService>();
                 });
             command.IsHidden = true;

--- a/UET/uet/Commands/Cluster/ClusterRunContainerdCommand.cs
+++ b/UET/uet/Commands/Cluster/ClusterRunContainerdCommand.cs
@@ -1,0 +1,983 @@
+﻿namespace UET.Commands.Cluster
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using Redpoint.Concurrency;
+    using Redpoint.IO;
+    using Redpoint.KubernetesManager.Manifests;
+    using Redpoint.KubernetesManager.Services;
+    using Redpoint.KubernetesManager.Services.Manifest;
+    using Redpoint.ProcessExecution;
+    using Redpoint.ServiceControl;
+    using System;
+    using System.CommandLine;
+    using System.CommandLine.Invocation;
+    using System.Formats.Tar;
+    using System.IO.Compression;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class ClusterRunContainerdCommand
+    {
+        internal sealed class Options
+        {
+            public Option<string> ManifestPath = new Option<string>("--manifest-path", "The path to the cached manifest file to use across restarts. This file will be read on startup, and written to whenever we receive a new manifest from the RKM service.");
+        }
+
+        public static Command CreateRunContainerdCommand()
+        {
+            var options = new Options();
+            var command = new Command("run-containerd");
+            command.AddAllOptions(options);
+            command.AddCommonHandler<ClusterRunContainerdCommandInstance>(
+                options,
+                services =>
+                {
+                    if (OperatingSystem.IsWindows())
+                    {
+                        services.AddWindowsService(options =>
+                        {
+                            options.ServiceName = "RKM - Containerd";
+                        });
+                    }
+                    services.AddRkmServiceHelpers(false);
+                    services.AddHostedService<ContainerdHostedService>();
+                });
+            command.IsHidden = true;
+            return command;
+        }
+
+        private sealed class ClusterRunContainerdCommandInstance : ICommandInstance
+        {
+            private readonly IHostedServiceFromExecutable _hostedServiceFromExecutable;
+
+            public ClusterRunContainerdCommandInstance(
+                IHostedServiceFromExecutable hostedServiceFromExecutable)
+            {
+                _hostedServiceFromExecutable = hostedServiceFromExecutable;
+            }
+
+            public async Task<int> ExecuteAsync(InvocationContext context)
+            {
+                // Store the invocation context so that we can get the command line arguments inside the hosted service.
+                ContainerdHostedService.InvocationContext = context;
+
+                await _hostedServiceFromExecutable.RunHostedServicesAsync(context.GetCancellationToken());
+                return 0;
+            }
+        }
+
+        private class ContainerdHostedService : IHostedService
+        {
+            private readonly IHostApplicationLifetime _hostApplicationLifetime;
+            private readonly IGenericManifestClient _genericManifestClient;
+            private readonly IProcessMonitorFactory _processMonitorFactory;
+            private readonly IProcessExecutor _processExecutor;
+            private readonly IServiceControl _serviceControl;
+            private readonly ILogger<ContainerdHostedService> _logger;
+            private readonly Options _options;
+            private readonly Gate _containerdStarted;
+
+            private Task? _backgroundTask;
+
+            public static InvocationContext? InvocationContext;
+
+            public ContainerdHostedService(
+                IHostApplicationLifetime hostApplicationLifetime,
+                IGenericManifestClient genericManifestClient,
+                IProcessMonitorFactory processMonitorFactory,
+                IProcessExecutor processExecutor,
+                IServiceControl serviceControl,
+                ILogger<ContainerdHostedService> logger,
+                Options options)
+            {
+                _hostApplicationLifetime = hostApplicationLifetime;
+                _genericManifestClient = genericManifestClient;
+                _processMonitorFactory = processMonitorFactory;
+                _processExecutor = processExecutor;
+                _serviceControl = serviceControl;
+                _logger = logger;
+                _options = options;
+                _containerdStarted = new Gate();
+            }
+
+            private async Task<bool> ExtractTarGz(
+                MemoryStream archive,
+                string target,
+                CancellationToken cancellationToken,
+                string? trimLeading = null)
+            {
+                using var gzip = new GZipStream(archive, CompressionMode.Decompress);
+                using var tar = new TarReader(gzip);
+
+                var anyFailures = false;
+
+                while (tar.GetNextEntry() is TarEntry entry)
+                {
+                    var entryName = entry.Name;
+                    if (trimLeading != null && entryName.StartsWith(trimLeading, StringComparison.Ordinal))
+                    {
+                        entryName = entryName.Substring(trimLeading.Length + 1);
+                        if (string.IsNullOrWhiteSpace(entryName))
+                        {
+                            continue;
+                        }
+                    }
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(Path.Combine(target, entryName))!);
+                    if (!entryName.EndsWith('\\') && !entryName.EndsWith('/') && !string.IsNullOrWhiteSpace(entryName))
+                    {
+                        _logger.LogInformation($"Extracting: {entryName}");
+                        await entry.ExtractToFileAsync(Path.Combine(target, entryName + ".tmp"), overwrite: true, cancellationToken);
+                        try
+                        {
+                            File.Move(Path.Combine(target, entryName + ".tmp"), Path.Combine(target, entryName), true);
+                        }
+                        catch (UnauthorizedAccessException) when (File.Exists(Path.Combine(target, entryName)))
+                        {
+                            _logger.LogWarning($"Unable to overwrite existing file: {Path.Combine(target, entryName)}");
+                            anyFailures = true;
+                        }
+                    }
+                }
+
+                return !anyFailures;
+            }
+
+            private async Task RunWithManifestAsync(ContainerdManifest manifest, CancellationToken cancellationToken)
+            {
+                // Log the version of containerd that we're about to run.
+                var versionWithSuffix = manifest.ContainerdVersion;
+                if (!string.IsNullOrWhiteSpace(manifest.RuncVersion) &&
+                    !OperatingSystem.IsWindows())
+                {
+                    versionWithSuffix += "-" + manifest.RuncVersion;
+                }
+                if (manifest.UseRedpointContainerd)
+                {
+                    versionWithSuffix += "-redpoint";
+                }
+                _logger.LogInformation($"Received manifest; attempting to start containerd '{versionWithSuffix}'...");
+
+                // Check if containerd is already installed.
+                var containerdInstallPath = Path.Combine(
+                    manifest.ContainerdInstallRootPath,
+                    versionWithSuffix);
+                if (!Directory.Exists(containerdInstallPath) ||
+                    !File.Exists(Path.Combine(containerdInstallPath, ".rkm-flag")))
+                {
+                    _logger.LogInformation($"Downloading and installing containerd '{versionWithSuffix}'...");
+
+                    // Erase any previous partial download/extract.
+                    if (Directory.Exists(containerdInstallPath))
+                    {
+                        await DirectoryAsync.DeleteAsync(containerdInstallPath, true);
+                    }
+                    Directory.CreateDirectory(containerdInstallPath);
+
+                    // Download and extract containerd in-memory, without caching the download on disk.
+                    {
+                        var platformName = OperatingSystem.IsWindows() ? "windows" : "linux";
+                        var containerdUri = new Uri($"https://github.com/containerd/containerd/releases/download/v{manifest.ContainerdVersion}/containerd-{manifest.ContainerdVersion}-{platformName}-amd64.tar.gz");
+                        _logger.LogInformation($"Downloading and extracting primary containerd archive from '{containerdUri}'...");
+                        using (var archiveMemory = new MemoryStream())
+                        {
+                            // Download the archive.
+                            using (var httpClient = new HttpClient())
+                            {
+                                using (var stream = await httpClient.GetStreamAsync(containerdUri, cancellationToken))
+                                {
+                                    await stream.CopyToAsync(archiveMemory, cancellationToken);
+                                }
+                            }
+
+                            // Rewind to the beginning.
+                            archiveMemory.Seek(0, SeekOrigin.Begin);
+
+                            // Extract containerd to the target directory.
+                            if (!await ExtractTarGz(
+                                archiveMemory,
+                                containerdInstallPath,
+                                cancellationToken))
+                            {
+                                _logger.LogError("Failed to extract containerd to installation path.");
+                                return;
+                            }
+                        }
+                        _logger.LogInformation($"Downloaded and extracted primary containerd archive from '{containerdUri}' to '{containerdInstallPath}'.");
+                    }
+
+                    // If we are on Linux, we need to download runc.
+                    if (OperatingSystem.IsLinux())
+                    {
+                        var runcUri = new Uri($"https://github.com/opencontainers/runc/releases/download/v{manifest.RuncVersion}/runc.amd64");
+                        var runcPath = Path.Combine(containerdInstallPath, "bin", "runc");
+                        _logger.LogInformation($"Downloading runc from '{runcUri}'...");
+                        using (var fileStream = new FileStream(runcPath + ".tmp", FileMode.Create, FileAccess.ReadWrite))
+                        {
+                            using (var httpClient = new HttpClient())
+                            {
+                                using (var stream = await httpClient.GetStreamAsync(runcUri, cancellationToken))
+                                {
+                                    await stream.CopyToAsync(fileStream, cancellationToken);
+                                }
+                            }
+                        }
+                        File.Move(runcPath + ".tmp", runcPath, true);
+                        _logger.LogInformation($"Downloaded runc from '{runcUri}' to '{runcPath}'.");
+                    }
+
+                    // If we are on Windows, we may need to download the Redpoint variant of containerd.
+                    if (OperatingSystem.IsWindows() && manifest.UseRedpointContainerd)
+                    {
+                        var redpointUri = new Uri($"https://dl-public.redpoint.games/file/dl-public-redpoint-games/redpoint-containerd-for-win11-{manifest.ContainerdVersion}.zip");
+                        _logger.LogInformation($"Downloading and extracting Redpoint containerd archive from '{redpointUri}'...");
+                        using (var archiveMemory = new MemoryStream())
+                        {
+                            // Download the archive.
+                            using (var httpClient = new HttpClient())
+                            {
+                                using (var stream = await httpClient.GetStreamAsync(redpointUri, cancellationToken))
+                                {
+                                    await stream.CopyToAsync(archiveMemory, cancellationToken);
+                                }
+                            }
+
+                            // Rewind to the beginning.
+                            archiveMemory.Seek(0, SeekOrigin.Begin);
+
+                            // Extract containerd over the top of the existing containerd binary.
+                            var foundContainerdOverride = false;
+                            using var zip = new ZipArchive(archiveMemory, ZipArchiveMode.Read, true);
+                            foreach (var entry in zip.Entries)
+                            {
+                                if (entry.Name == "containerd.exe")
+                                {
+                                    var targetPath = Path.Combine(
+                                        containerdInstallPath,
+                                        "bin",
+                                        "containerd.exe");
+                                    _logger.LogInformation($"Extracting '{entry.FullName}' to '{targetPath}'...");
+                                    entry.ExtractToFile(
+                                        targetPath,
+                                        true);
+                                    foundContainerdOverride = true;
+                                }
+                            }
+                            if (!foundContainerdOverride)
+                            {
+                                _logger.LogError("Unable to find containerd.exe within Redpoint containerd archive.");
+                                return;
+                            }
+                        }
+                        _logger.LogInformation($"Downloaded and extracted Redpoint containerd archive from '{redpointUri}'.");
+                    }
+
+                    // Mark this install as having been completed.
+                    File.WriteAllText(
+                        Path.Combine(containerdInstallPath, ".rkm-flag"),
+                        "ok");
+                }
+
+                // Log that containerd is now ready on disk.
+                _logger.LogInformation($"Containerd '{versionWithSuffix}' is now ready on disk.");
+
+                // Write out the containerd configuration file.
+                Directory.CreateDirectory(manifest.ContainerdStatePath);
+                if (OperatingSystem.IsLinux())
+                {
+                    await File.WriteAllTextAsync(
+                        Path.Combine(manifest.ContainerdStatePath, "config.yaml"),
+                        $$"""
+                        disabled_plugins = []
+                        imports = []
+                        oom_score = 0
+                        plugin_dir = ""
+                        required_plugins = []
+                        root = "{{manifest.ContainerdStatePath}}/root"
+                        state = "{{manifest.ContainerdStatePath}}/state"
+                        temp = ""
+                        version = 2
+
+                        [cgroup]
+                          path = ""
+
+                        [debug]
+                          address = ""
+                          format = ""
+                          gid = 0
+                          level = ""
+                          uid = 0
+
+                        [grpc]
+                          address = "{{manifest.ContainerdStatePath}}/containerd.sock"
+                          gid = 0
+                          max_recv_message_size = 16777216
+                          max_send_message_size = 16777216
+                          tcp_address = ""
+                          tcp_tls_ca = ""
+                          tcp_tls_cert = ""
+                          tcp_tls_key = ""
+                          uid = 0
+
+                        [metrics]
+                          address = ""
+                          grpc_histogram = false
+
+                        [plugins]
+
+                          [plugins."io.containerd.gc.v1.scheduler"]
+                            deletion_threshold = 0
+                            mutation_threshold = 100
+                            pause_threshold = 0.02
+                            schedule_delay = "0s"
+                            startup_delay = "100ms"
+
+                          [plugins."io.containerd.grpc.v1.cri"]
+                            device_ownership_from_security_context = false
+                            disable_apparmor = false
+                            disable_cgroup = false
+                            disable_hugetlb_controller = true
+                            disable_proc_mount = false
+                            disable_tcp_service = true
+                            enable_selinux = false
+                            enable_tls_streaming = false
+                            enable_unprivileged_icmp = false
+                            enable_unprivileged_ports = false
+                            ignore_image_defined_volumes = false
+                            max_concurrent_downloads = 3
+                            max_container_log_line_size = 16384
+                            netns_mounts_under_state_dir = false
+                            restrict_oom_score_adj = false
+                            sandbox_image = "registry.k8s.io/pause:3.6"
+                            selinux_category_range = 1024
+                            stats_collect_period = 10
+                            stream_idle_timeout = "4h0m0s"
+                            stream_server_address = "127.0.0.1"
+                            stream_server_port = "0"
+                            systemd_cgroup = false
+                            tolerate_missing_hugetlb_controller = true
+                            unset_seccomp_profile = ""
+
+                            [plugins."io.containerd.grpc.v1.cri".cni]
+                              bin_dir = "{{manifest.CniPluginsPath}}"
+                              conf_dir = "{{manifest.ContainerdStatePath}}/cni/net.d"
+                              conf_template = ""
+                              ip_pref = ""
+                              max_conf_num = 1
+
+                            [plugins."io.containerd.grpc.v1.cri".containerd]
+                              default_runtime_name = "runc"
+                              disable_snapshot_annotations = true
+                              discard_unpacked_layers = false
+                              ignore_rdt_not_enabled_errors = false
+                              no_pivot = false
+                              snapshotter = "overlayfs"
+
+                              [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+                                base_runtime_spec = ""
+                                cni_conf_dir = ""
+                                cni_max_conf_num = 0
+                                container_annotations = []
+                                pod_annotations = []
+                                privileged_without_host_devices = false
+                                runtime_engine = ""
+                                runtime_path = ""
+                                runtime_root = ""
+                                runtime_type = ""
+
+                                [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+                              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+                                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+                                  base_runtime_spec = ""
+                                  cni_conf_dir = ""
+                                  cni_max_conf_num = 0
+                                  container_annotations = []
+                                  pod_annotations = []
+                                  privileged_without_host_devices = false
+                                  runtime_engine = ""
+                                  runtime_path = ""
+                                  runtime_root = ""
+                                  runtime_type = "io.containerd.runc.v2"
+
+                                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                                    BinaryName = "{{containerdInstallPath}}/bin/runc"
+                                    CriuImagePath = ""
+                                    CriuPath = ""
+                                    CriuWorkPath = ""
+                                    IoGid = 0
+                                    IoUid = 0
+                                    NoNewKeyring = false
+                                    NoPivotRoot = false
+                                    Root = ""
+                                    ShimCgroup = ""
+                                    SystemdCgroup = false
+
+                              [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+                                base_runtime_spec = ""
+                                cni_conf_dir = ""
+                                cni_max_conf_num = 0
+                                container_annotations = []
+                                pod_annotations = []
+                                privileged_without_host_devices = false
+                                runtime_engine = ""
+                                runtime_path = ""
+                                runtime_root = ""
+                                runtime_type = ""
+
+                                [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+                            [plugins."io.containerd.grpc.v1.cri".image_decryption]
+                              key_model = "node"
+
+                            [plugins."io.containerd.grpc.v1.cri".registry]
+                              config_path = ""
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+                            [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+                              tls_cert_file = ""
+                              tls_key_file = ""
+
+                          [plugins."io.containerd.internal.v1.opt"]
+                            path = "{{manifest.ContainerdStatePath}}/root/opt"
+
+                          [plugins."io.containerd.internal.v1.restart"]
+                            interval = "10s"
+
+                          [plugins."io.containerd.internal.v1.tracing"]
+                            sampling_ratio = 1.0
+                            service_name = "containerd"
+
+                          [plugins."io.containerd.metadata.v1.bolt"]
+                            content_sharing_policy = "shared"
+
+                          [plugins."io.containerd.monitor.v1.cgroups"]
+                            no_prometheus = false
+
+                          [plugins."io.containerd.runtime.v1.linux"]
+                            no_shim = false
+                            runtime = "runc"
+                            runtime_root = ""
+                            shim = "containerd-shim"
+                            shim_debug = false
+
+                          [plugins."io.containerd.runtime.v2.task"]
+                            platforms = ["linux/amd64"]
+                            sched_core = false
+
+                          [plugins."io.containerd.service.v1.diff-service"]
+                            default = ["walking"]
+
+                          [plugins."io.containerd.service.v1.tasks-service"]
+                            rdt_config_file = ""
+
+                          [plugins."io.containerd.snapshotter.v1.aufs"]
+                            root_path = ""
+
+                          [plugins."io.containerd.snapshotter.v1.btrfs"]
+                            root_path = ""
+
+                          [plugins."io.containerd.snapshotter.v1.devmapper"]
+                            async_remove = false
+                            base_image_size = ""
+                            discard_blocks = false
+                            fs_options = ""
+                            fs_type = ""
+                            pool_name = ""
+                            root_path = ""
+
+                          [plugins."io.containerd.snapshotter.v1.native"]
+                            root_path = ""
+
+                          [plugins."io.containerd.snapshotter.v1.overlayfs"]
+                            root_path = ""
+                            upperdir_label = false
+
+                          [plugins."io.containerd.snapshotter.v1.zfs"]
+                            root_path = ""
+
+                          [plugins."io.containerd.tracing.processor.v1.otlp"]
+                            endpoint = ""
+                            insecure = false
+                            protocol = ""
+
+                        [proxy_plugins]
+
+                        [stream_processors]
+
+                          [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+                            accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+                            args = ["--decryption-keys-path", "{{manifest.ContainerdStatePath}}/ocicrypt/keys"]
+                            env = ["OCICRYPT_KEYPROVIDER_CONFIG={{manifest.ContainerdStatePath}}/ocicrypt/ocicrypt_keyprovider.conf"]
+                            path = "ctd-decoder"
+                            returns = "application/vnd.oci.image.layer.v1.tar"
+
+                          [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+                            accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+                            args = ["--decryption-keys-path", "{{manifest.ContainerdStatePath}}/ocicrypt/keys"]
+                            env = ["OCICRYPT_KEYPROVIDER_CONFIG={{manifest.ContainerdStatePath}}/ocicrypt/ocicrypt_keyprovider.conf"]
+                            path = "ctd-decoder"
+                            returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+                        [timeouts]
+                          "io.containerd.timeout.bolt.open" = "0s"
+                          "io.containerd.timeout.shim.cleanup" = "5s"
+                          "io.containerd.timeout.shim.load" = "5s"
+                          "io.containerd.timeout.shim.shutdown" = "3s"
+                          "io.containerd.timeout.task.state" = "2s"
+
+                        [ttrpc]
+                          address = ""
+                          gid = 0
+                          uid = 0
+                        """,
+                        cancellationToken);
+                }
+                else
+                {
+                    var containerdStatePath = manifest.ContainerdStatePath.Replace("\\", "\\\\", StringComparison.Ordinal);
+                    var cniPluginsPath = manifest.CniPluginsPath.Replace("\\", "\\\\", StringComparison.Ordinal);
+
+                    await File.WriteAllTextAsync(
+                        Path.Combine(manifest.ContainerdStatePath, "config.yaml"),
+                        $$"""
+                        disabled_plugins = []
+                        imports = []
+                        oom_score = 0
+                        plugin_dir = ""
+                        required_plugins = []
+                        root = "{{containerdStatePath}}\\root"
+                        state = "{{containerdStatePath}}\\state"
+                        temp = ""
+                        version = 2
+
+                        [cgroup]
+                          path = ""
+
+                        [debug]
+                          address = ""
+                          format = ""
+                          gid = 0
+                          level = ""
+                          uid = 0
+
+                        [grpc]
+                          address = "\\\\.\\pipe\\containerd-containerd"
+                          gid = 0
+                          max_recv_message_size = 16777216
+                          max_send_message_size = 16777216
+                          tcp_address = ""
+                          tcp_tls_ca = ""
+                          tcp_tls_cert = ""
+                          tcp_tls_key = ""
+                          uid = 0
+
+                        [metrics]
+                          address = ""
+                          grpc_histogram = false
+
+                        [plugins]
+
+                          [plugins."io.containerd.gc.v1.scheduler"]
+                            deletion_threshold = 0
+                            mutation_threshold = 100
+                            pause_threshold = 0.02
+                            schedule_delay = "0s"
+                            startup_delay = "100ms"
+
+                          [plugins."io.containerd.grpc.v1.cri"]
+                            device_ownership_from_security_context = false
+                            disable_apparmor = false
+                            disable_cgroup = false
+                            disable_hugetlb_controller = false
+                            disable_proc_mount = false
+                            disable_tcp_service = true
+                            enable_selinux = false
+                            enable_tls_streaming = false
+                            enable_unprivileged_icmp = false
+                            enable_unprivileged_ports = false
+                            ignore_image_defined_volumes = false
+                            max_concurrent_downloads = 3
+                            max_container_log_line_size = 16384
+                            netns_mounts_under_state_dir = false
+                            restrict_oom_score_adj = false
+                            sandbox_image = "registry.k8s.io/pause:3.6"
+                            selinux_category_range = 0
+                            stats_collect_period = 10
+                            stream_idle_timeout = "4h0m0s"
+                            stream_server_address = "127.0.0.1"
+                            stream_server_port = "0"
+                            systemd_cgroup = false
+                            tolerate_missing_hugetlb_controller = false
+                            unset_seccomp_profile = ""
+
+                            [plugins."io.containerd.grpc.v1.cri".cni]
+                              bin_dir = "{{cniPluginsPath}}"
+                              conf_dir = "{{containerdStatePath}}\\cni\\conf"
+                              conf_template = ""
+                              ip_pref = ""
+                              max_conf_num = 1
+
+                            [plugins."io.containerd.grpc.v1.cri".containerd]
+                              default_runtime_name = "runhcs-wcow-process"
+                              disable_snapshot_annotations = false
+                              discard_unpacked_layers = false
+                              ignore_rdt_not_enabled_errors = false
+                              no_pivot = false
+                              snapshotter = "windows"
+
+                              [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+                                base_runtime_spec = ""
+                                cni_conf_dir = ""
+                                cni_max_conf_num = 0
+                                container_annotations = []
+                                pod_annotations = []
+                                privileged_without_host_devices = false
+                                runtime_engine = ""
+                                runtime_path = ""
+                                runtime_root = ""
+                                runtime_type = ""
+
+                                [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+                              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+                                [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
+                                  base_runtime_spec = ""
+                                  cni_conf_dir = ""
+                                  cni_max_conf_num = 0
+                                  container_annotations = []
+                                  pod_annotations = []
+                                  privileged_without_host_devices = false
+                                  runtime_engine = ""
+                                  runtime_path = ""
+                                  runtime_root = ""
+                                  runtime_type = "io.containerd.runhcs.v1"
+
+                                  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process.options]
+
+                              [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+                                base_runtime_spec = ""
+                                cni_conf_dir = ""
+                                cni_max_conf_num = 0
+                                container_annotations = []
+                                pod_annotations = []
+                                privileged_without_host_devices = false
+                                runtime_engine = ""
+                                runtime_path = ""
+                                runtime_root = ""
+                                runtime_type = ""
+
+                                [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+                            [plugins."io.containerd.grpc.v1.cri".image_decryption]
+                              key_model = "node"
+
+                            [plugins."io.containerd.grpc.v1.cri".registry]
+                              config_path = ""
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+                              [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+                            [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+                              tls_cert_file = ""
+                              tls_key_file = ""
+
+                          [plugins."io.containerd.internal.v1.opt"]
+                            path = "{{containerdStatePath}}\\root\\opt"
+
+                          [plugins."io.containerd.internal.v1.restart"]
+                            interval = "10s"
+
+                          [plugins."io.containerd.internal.v1.tracing"]
+                            sampling_ratio = 1.0
+                            service_name = "containerd"
+
+                          [plugins."io.containerd.metadata.v1.bolt"]
+                            content_sharing_policy = "shared"
+
+                          [plugins."io.containerd.runtime.v2.task"]
+                            platforms = ["windows/amd64", "linux/amd64"]
+                            sched_core = false
+
+                          [plugins."io.containerd.service.v1.diff-service"]
+                            default = ["windows", "windows-lcow"]
+
+                          [plugins."io.containerd.service.v1.tasks-service"]
+                            rdt_config_file = ""
+
+                          [plugins."io.containerd.tracing.processor.v1.otlp"]
+                            endpoint = ""
+                            insecure = false
+                            protocol = ""
+
+                        [proxy_plugins]
+
+                        [stream_processors]
+
+                          [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+                            accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+                            args = ["--decryption-keys-path", "{{containerdStatePath}}\\ocicrypt\\keys"]
+                            env = ["OCICRYPT_KEYPROVIDER_CONFIG={{containerdStatePath}}\\ocicrypt\\ocicrypt_keyprovider.conf"]
+                            path = "ctd-decoder"
+                            returns = "application/vnd.oci.image.layer.v1.tar"
+
+                          [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+                            accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+                            args = ["--decryption-keys-path", "{{containerdStatePath}}\\ocicrypt\\keys"]
+                            env = ["OCICRYPT_KEYPROVIDER_CONFIG={{containerdStatePath}}\\ocicrypt\\ocicrypt_keyprovider.conf"]
+                            path = "ctd-decoder"
+                            returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+                        [timeouts]
+                          "io.containerd.timeout.bolt.open" = "0s"
+                          "io.containerd.timeout.shim.cleanup" = "5s"
+                          "io.containerd.timeout.shim.load" = "5s"
+                          "io.containerd.timeout.shim.shutdown" = "3s"
+                          "io.containerd.timeout.task.state" = "2s"
+
+                        [ttrpc]
+                          address = ""
+                          gid = 0
+                          uid = 0
+                        """,
+                        cancellationToken);
+                }
+
+                // Create the containerd process specification.
+                var containerdProcess = _processMonitorFactory.CreatePerpetualProcess(
+                    new Redpoint.KubernetesManager.Models.ProcessSpecification(
+                        filename: Path.Combine(containerdInstallPath, "bin", "containerd"),
+                        arguments:
+                        [
+                            "--config",
+                            Path.Combine(manifest.ContainerdStatePath, "config.yaml")
+                        ],
+                        afterStart: _ =>
+                        {
+                            _containerdStarted.Open();
+                            return Task.CompletedTask;
+                        }));
+
+                // Create a cancellation token that we can use to stop containerd.
+                using var terminateContainerd = new CancellationTokenSource();
+
+                // Start containerd and use our custom cancellation token.
+                _logger.LogInformation($"Starting containerd process...");
+                var containerdTask = containerdProcess.RunAsync(terminateContainerd.Token);
+
+                // Wait until the main cancellation token is cancelled.
+                try
+                {
+                    _logger.LogInformation($"Waiting for termination signal...");
+                    await Task.Delay(-1, cancellationToken);
+                }
+                catch
+                {
+                }
+                _logger.LogInformation($"containerd has been asked to shutdown.");
+
+                // We've been asked to stop containerd. If the host is fully shutting down,
+                // clean up the containers before that happens.
+                var kubeletServiceName = OperatingSystem.IsWindows() ? "RKM - Kubelet" : "rkm-kubelet";
+                var kubeletStopped = false;
+                if (_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
+                {
+                    // Stop the kubelet service, if it exists. This will prevent kubelet from
+                    // scheduling containers while we're cleaning up.
+                    try
+                    {
+                        if (await _serviceControl.IsServiceRunning(kubeletServiceName))
+                        {
+                            _logger.LogInformation($"Stopping the kubelet service...");
+                            await _serviceControl.StopService(kubeletServiceName);
+                            kubeletStopped = true;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, $"Unable to stop kubelet service: {ex.Message}");
+                    }
+
+                    // Clean up the containers.
+                    try
+                    {
+                        _logger.LogInformation($"Fetching a list of containers to stop...");
+                        var containerListStringBuilder = new StringBuilder();
+                        await _processExecutor.ExecuteAsync(
+                            new ProcessSpecification
+                            {
+                                FilePath = Path.Combine(containerdInstallPath, "bin", "ctr"),
+                                Arguments =
+                                [
+                                    "--namespace",
+                                    "k8s.io",
+                                    "c",
+                                    "list"
+                                ]
+                            },
+                            CaptureSpecification.CreateFromStdoutStringBuilder(containerListStringBuilder),
+                            _hostApplicationLifetime.ApplicationStopped);
+                        var listLines = containerListStringBuilder.ToString().Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+                        var containerIds = new List<string>();
+                        var containerRegex = new Regex("^([a-f0-9]+)\\s");
+                        foreach (var line in listLines)
+                        {
+                            var match = containerRegex.Match(line);
+                            if (match.Success)
+                            {
+                                containerIds.Add(match.Groups[1].Value);
+                            }
+                        }
+
+                        _logger.LogInformation($"{containerIds.Count} containers to terminate.");
+                        foreach (var containerId in containerIds)
+                        {
+                            _logger.LogInformation($"Deleting container: {containerId}");
+                            await _processExecutor.ExecuteAsync(
+                                new ProcessSpecification
+                                {
+                                    FilePath = Path.Combine(containerdInstallPath, "bin", "ctr"),
+                                    Arguments =
+                                    [
+                                        "--namespace",
+                                        "k8s.io",
+                                        "c",
+                                        "delete",
+                                        containerId,
+                                    ]
+                                },
+                                CaptureSpecification.Passthrough,
+                                _hostApplicationLifetime.ApplicationStopped);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, $"Failed to clean up containers: {ex.Message}");
+                    }
+                }
+
+                // Terminate the containerd process.
+                _logger.LogInformation($"Terminating the containerd process...");
+                terminateContainerd.Cancel();
+
+                // Wait for containerd to stop.
+                try
+                {
+                    await containerdTask;
+                }
+                catch
+                {
+                }
+                terminateContainerd.Dispose();
+                _logger.LogInformation($"containerd has exited.");
+
+                // If we stopped the kubelet service, we now have to start the kubelet service again so
+                // that the running state of the service is preserved across containerd restarts.
+                if (kubeletStopped)
+                {
+                    try
+                    {
+                        _logger.LogInformation($"Starting the kubelet service to restore it's state...");
+                        await _serviceControl.StartService(kubeletServiceName);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, $"Unable to start kubelet service: {ex.Message}");
+                    }
+                }
+            }
+
+            private async Task RunAsync()
+            {
+                // Start the manifest poll from the main RKM service.
+                await _genericManifestClient.RegisterAndRunWithManifestAsync(
+                    new Uri("ws://127.0.0.1:8375/containerd"),
+                    InvocationContext?.ParseResult.GetValueForOption(_options.ManifestPath),
+                    ManifestJsonSerializerContext.Default.ContainerdManifest,
+                    async (manifest, cancellationToken) =>
+                    {
+                        try
+                        {
+                            await RunWithManifestAsync(manifest, cancellationToken);
+                        }
+                        finally
+                        {
+                            if (!cancellationToken.IsCancellationRequested)
+                            {
+                                // If we exit this function, and cancellation isn't requested, something has gone wrong
+                                // and the whole service should terminate (instead of us idling while the containerd
+                                // process isn't running).
+                                _logger.LogError("Manifest execution loop exited unexpectedly.");
+                                _hostApplicationLifetime.StopApplication();
+                            }
+                        }
+                    },
+                    _hostApplicationLifetime.ApplicationStopping);
+            }
+
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                // Start in the background.
+                _backgroundTask = Task.Run(
+                    async () =>
+                    {
+                        try
+                        {
+                            // Run the main loop.
+                            await RunAsync().ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            // If we ever exit this function, and the application is not already stopping, request it to stop now.
+                            if (!_hostApplicationLifetime.ApplicationStopping.IsCancellationRequested)
+                            {
+                                _logger.LogError("Primary execution loop exited unexpectedly.");
+                                _hostApplicationLifetime.StopApplication();
+                            }
+                        }
+                    },
+                    cancellationToken);
+
+                // Wait until containerd starts, or the service start is cancelled.
+                await _containerdStarted.WaitAsync(cancellationToken);
+            }
+
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                // If we have a background task, wait for it to complete.
+                if (_backgroundTask != null)
+                {
+                    try
+                    {
+                        await _backgroundTask;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, $"Unexpected exception when stopping containerd: {ex.Message}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/UET/uet/Commands/Cluster/ClusterStopCommand.cs
+++ b/UET/uet/Commands/Cluster/ClusterStopCommand.cs
@@ -52,14 +52,12 @@ namespace UET.Commands.Cluster
 
             public async Task<int> ExecuteAsync(InvocationContext context)
             {
-                var serviceName = OperatingSystem.IsWindows() ? "RKM" : "rkm";
-
-                if (await _serviceControl.IsServiceInstalled(serviceName))
+                if (await _serviceControl.IsServiceInstalled("rkm"))
                 {
-                    if (await _serviceControl.IsServiceRunning(serviceName))
+                    if (await _serviceControl.IsServiceRunning("rkm"))
                     {
                         _logger.LogInformation("Stopping RKM service...");
-                        await _serviceControl.StopService(serviceName);
+                        await _serviceControl.StopService("rkm");
                     }
                     else
                     {
@@ -67,7 +65,7 @@ namespace UET.Commands.Cluster
                     }
 
                     _logger.LogInformation("Uninstalling RKM service, so it doesn't run at startup...");
-                    await _serviceControl.UninstallService(serviceName);
+                    await _serviceControl.UninstallService("rkm");
                 }
                 else
                 {

--- a/UET/uet/Commands/Cluster/DefaultHostedServiceFromExecutable.cs
+++ b/UET/uet/Commands/Cluster/DefaultHostedServiceFromExecutable.cs
@@ -109,7 +109,10 @@
 
                 try
                 {
-                    await _hostLifetime!.StopAsync(cts.Token);
+                    if (_hostLifetime != null)
+                    {
+                        await _hostLifetime!.StopAsync(cts.Token);
+                    }
                 }
                 catch
                 {

--- a/UET/uet/Commands/Cluster/DefaultHostedServiceFromExecutable.cs
+++ b/UET/uet/Commands/Cluster/DefaultHostedServiceFromExecutable.cs
@@ -1,0 +1,122 @@
+﻿namespace UET.Commands.Cluster
+{
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Hosting.WindowsServices;
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using UET.Commands.Internal.Rkm;
+
+    internal class DefaultHostedServiceFromExecutable : IHostedServiceFromExecutable
+    {
+        private readonly ILogger<DefaultHostedServiceFromExecutable> _logger;
+        private readonly IEnumerable<IHostedService> _hostedServices;
+        private readonly RkmHostApplicationLifetime _hostApplicationLifetime;
+        private readonly IHostLifetime? _hostLifetime;
+
+        public DefaultHostedServiceFromExecutable(
+            ILogger<DefaultHostedServiceFromExecutable> logger,
+            IEnumerable<IHostedService> hostedServices,
+            RkmHostApplicationLifetime hostApplicationLifetime,
+            IHostLifetime? hostLifetime = null)
+        {
+            _logger = logger;
+            _hostedServices = hostedServices;
+            _hostApplicationLifetime = hostApplicationLifetime;
+            _hostLifetime = hostLifetime;
+        }
+
+        public async Task RunHostedServicesAsync(CancellationToken cancellationToken)
+        {
+            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _hostApplicationLifetime.ApplicationStopped,
+                _hostApplicationLifetime.ApplicationStopping);
+
+            if (OperatingSystem.IsWindows() && WindowsServiceHelpers.IsWindowsService())
+            {
+                _logger.LogInformation("Waiting for service start...");
+                await _hostLifetime!.WaitForStartAsync(cancellationTokenSource.Token);
+            }
+
+            try
+            {
+                // Wire up Ctrl-C to request stop, to allow start to be cancelled.
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _hostApplicationLifetime.StopRequestedGate.Open();
+                }
+                else
+                {
+                    cancellationToken.Register(_hostApplicationLifetime.StopRequestedGate.Open);
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Start services.
+                foreach (var hostedService in _hostedServices)
+                {
+                    _logger.LogInformation($"Starting hosted service '{hostedService.GetType().FullName}'...");
+                    try
+                    {
+                        await hostedService.StartAsync(cancellationTokenSource.Token);
+                        _logger.LogInformation($"Started hosted service '{hostedService.GetType().FullName}'.");
+                    }
+                    catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+                    {
+                        // Application started shutting down during start logic.
+                        return;
+                    }
+                }
+
+                // Tells the service lifetime that we have now started. The service
+                // lifetime will call StopApplication when we should shutdown, which
+                // will open the gate.
+                _hostApplicationLifetime.CtsStarted.Cancel();
+
+                // Wait until shutdown is requested.
+                _logger.LogInformation("RKM is waiting for StopRequestedGate to be opened...");
+                await _hostApplicationLifetime.StopRequestedGate.WaitAsync(CancellationToken.None);
+                _logger.LogInformation("RKM is now shutting down due to StopRequestedGate being opened.");
+            }
+            finally
+            {
+                _logger.LogInformation("Shutting down service...");
+
+                if (!_hostApplicationLifetime.CtsStopping.IsCancellationRequested)
+                {
+                    _hostApplicationLifetime.CtsStopping.Cancel();
+                }
+
+                using var cts = new CancellationTokenSource(30000);
+                using var stopCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    cts.Token,
+                    _hostApplicationLifetime.ApplicationStopped);
+
+                foreach (var hostedService in _hostedServices)
+                {
+                    _logger.LogInformation($"Stopping hosted service '{hostedService.GetType().FullName}'...");
+                    try
+                    {
+                        await hostedService.StopAsync(stopCts.Token);
+                        _logger.LogInformation($"Stopped hosted service '{hostedService.GetType().FullName}'.");
+                    }
+                    catch (OperationCanceledException) when (stopCts.Token.IsCancellationRequested)
+                    {
+                        _logger.LogWarning($"Stop of hosted service '{hostedService.GetType().FullName}' was cancelled due to timeout.");
+                    }
+                }
+
+                try
+                {
+                    await _hostLifetime!.StopAsync(cts.Token);
+                }
+                catch
+                {
+                }
+                _hostApplicationLifetime.CtsStopped.Cancel();
+                _logger.LogInformation("Service has been stopped.");
+            }
+        }
+    }
+}

--- a/UET/uet/Commands/Cluster/DefaultRkmClusterControl.cs
+++ b/UET/uet/Commands/Cluster/DefaultRkmClusterControl.cs
@@ -73,16 +73,13 @@ namespace UET.Commands.Cluster
             }
 
             // Make sure the service is installed, up-to-date and started.
-            string serviceName;
             string executablePathAndArguments;
             if (OperatingSystem.IsWindows())
             {
-                serviceName = "RKM";
                 executablePathAndArguments = $"{_selfLocation.GetUetLocalLocation(true)} internal rkm-service";
             }
             else if (OperatingSystem.IsLinux())
             {
-                serviceName = "rkm";
                 executablePathAndArguments = $"\"{_selfLocation.GetUetLocalLocation(true)}\" internal rkm-service";
             }
             else
@@ -91,10 +88,10 @@ namespace UET.Commands.Cluster
                 return 1;
             }
 
-            var isServiceInstalled = await _serviceControl.IsServiceInstalled(serviceName);
+            var isServiceInstalled = await _serviceControl.IsServiceInstalled("rkm");
             if (isServiceInstalled)
             {
-                var currentExecutableAndArguments = await _serviceControl.GetServiceExecutableAndArguments(serviceName);
+                var currentExecutableAndArguments = await _serviceControl.GetServiceExecutableAndArguments("rkm");
                 if (currentExecutableAndArguments != executablePathAndArguments || args.Contains("--reinstall"))
                 {
                     if (!_serviceControl.HasPermissionToInstall)
@@ -103,8 +100,8 @@ namespace UET.Commands.Cluster
                     }
                     else
                     {
-                        await _serviceControl.StopService(serviceName);
-                        await _serviceControl.UninstallService(serviceName);
+                        await _serviceControl.StopService("rkm");
+                        await _serviceControl.UninstallService("rkm");
                         isServiceInstalled = false;
                     }
                 }
@@ -120,12 +117,12 @@ namespace UET.Commands.Cluster
                 {
                     _logger.LogInformation("Installing service...");
                     await _serviceControl.InstallService(
-                        serviceName,
-                        "RKM (Redpoint Kubernetes Manager) runs Kubernetes on your local machine.",
+                        "rkm",
+                        "RKM",
                         executablePathAndArguments);
                 }
             }
-            var isServiceStarted = await _serviceControl.IsServiceRunning(serviceName);
+            var isServiceStarted = await _serviceControl.IsServiceRunning("rkm");
             if (!isServiceStarted)
             {
                 if (!_serviceControl.HasPermissionToStart)
@@ -136,7 +133,7 @@ namespace UET.Commands.Cluster
                 else
                 {
                     _logger.LogInformation("Starting service...");
-                    await _serviceControl.StartService(serviceName);
+                    await _serviceControl.StartService("rkm");
                 }
             }
             else

--- a/UET/uet/Commands/Cluster/IHostedServiceFromExecutable.cs
+++ b/UET/uet/Commands/Cluster/IHostedServiceFromExecutable.cs
@@ -1,0 +1,9 @@
+﻿namespace UET.Commands.Cluster
+{
+    using System.Threading.Tasks;
+
+    internal interface IHostedServiceFromExecutable
+    {
+        Task RunHostedServicesAsync(CancellationToken cancellationToken);
+    }
+}

--- a/UET/uet/Commands/Cluster/RkmServiceContainerExtensions.cs
+++ b/UET/uet/Commands/Cluster/RkmServiceContainerExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace UET.Commands.Cluster
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Redpoint.KubernetesManager;
+    using UET.Commands.Internal.Rkm;
+    using UET.Commands.Internal.RkmService;
+
+    internal static class RkmServiceContainerExtensions
+    {
+        public static void AddRkmServiceHelpers(this IServiceCollection services, bool withPathProvider)
+        {
+            services.AddKubernetesManager(withPathProvider);
+            services.AddSingleton<IRkmVersionProvider, UetRkmVersionProvider>();
+            services.AddSingleton<IHostApplicationLifetime>(sp => sp.GetRequiredService<RkmHostApplicationLifetime>());
+            services.AddSingleton<RkmHostApplicationLifetime, RkmHostApplicationLifetime>();
+            services.AddSingleton<IHostEnvironment, RkmHostEnvironment>();
+            services.AddSingleton<IHostedServiceFromExecutable, DefaultHostedServiceFromExecutable>();
+        }
+    }
+}

--- a/UET/uet/Commands/Cluster/RkmServiceContainerExtensions.cs
+++ b/UET/uet/Commands/Cluster/RkmServiceContainerExtensions.cs
@@ -5,16 +5,17 @@
     using Redpoint.KubernetesManager;
     using UET.Commands.Internal.Rkm;
     using UET.Commands.Internal.RkmService;
+    using UET.Services;
 
     internal static class RkmServiceContainerExtensions
     {
-        public static void AddRkmServiceHelpers(this IServiceCollection services, bool withPathProvider)
+        public static void AddRkmServiceHelpers(this IServiceCollection services, bool withPathProvider, string applicationName)
         {
             services.AddKubernetesManager(withPathProvider);
             services.AddSingleton<IRkmVersionProvider, UetRkmVersionProvider>();
             services.AddSingleton<IHostApplicationLifetime>(sp => sp.GetRequiredService<RkmHostApplicationLifetime>());
             services.AddSingleton<RkmHostApplicationLifetime, RkmHostApplicationLifetime>();
-            services.AddSingleton<IHostEnvironment, RkmHostEnvironment>();
+            services.AddSingleton<IHostEnvironment>(sp => new RkmHostEnvironment(sp.GetRequiredService<ISelfLocation>(), applicationName));
             services.AddSingleton<IHostedServiceFromExecutable, DefaultHostedServiceFromExecutable>();
         }
     }

--- a/UET/uet/Commands/Internal/RkmService/RkmHostApplicationLifetime.cs
+++ b/UET/uet/Commands/Internal/RkmService/RkmHostApplicationLifetime.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.Hosting;
+using Redpoint.Concurrency;
+
+namespace UET.Commands.Internal.Rkm
+{
+    internal sealed class RkmHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        public readonly CancellationTokenSource CtsStarted;
+        public readonly CancellationTokenSource CtsStopping;
+        public readonly CancellationTokenSource CtsStopped;
+        public readonly Gate StopRequestedGate;
+
+        public RkmHostApplicationLifetime()
+        {
+            CtsStarted = new CancellationTokenSource();
+            CtsStopping = new CancellationTokenSource();
+            CtsStopped = new CancellationTokenSource();
+            StopRequestedGate = new Gate();
+        }
+
+        public CancellationToken ApplicationStarted => CtsStarted.Token;
+
+        public CancellationToken ApplicationStopping => CtsStopping.Token;
+
+        public CancellationToken ApplicationStopped => CtsStopped.Token;
+
+        public void StopApplication()
+        {
+            StopRequestedGate.Open();
+            CtsStopping.Cancel();
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)CtsStarted).Dispose();
+            ((IDisposable)CtsStopping).Dispose();
+            ((IDisposable)CtsStopped).Dispose();
+        }
+    }
+}

--- a/UET/uet/Commands/Internal/RkmService/RkmHostEnvironment.cs
+++ b/UET/uet/Commands/Internal/RkmService/RkmHostEnvironment.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using UET.Services;
+
+namespace UET.Commands.Internal.Rkm
+{
+    internal sealed class RkmHostEnvironment : IHostEnvironment
+    {
+        public RkmHostEnvironment(
+            ISelfLocation selfLocation)
+        {
+            EnvironmentName = "Production";
+            ApplicationName = "RKM";
+            ContentRootPath = Path.GetDirectoryName(selfLocation.GetUetLocalLocation(true))!;
+            ContentRootFileProvider = null!;
+        }
+
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; }
+        public string ContentRootPath { get; set; }
+        public IFileProvider ContentRootFileProvider { get; set; }
+    }
+}

--- a/UET/uet/Commands/Internal/RkmService/RkmHostEnvironment.cs
+++ b/UET/uet/Commands/Internal/RkmService/RkmHostEnvironment.cs
@@ -7,10 +7,11 @@ namespace UET.Commands.Internal.Rkm
     internal sealed class RkmHostEnvironment : IHostEnvironment
     {
         public RkmHostEnvironment(
-            ISelfLocation selfLocation)
+            ISelfLocation selfLocation,
+            string applicationName)
         {
             EnvironmentName = "Production";
-            ApplicationName = "RKM";
+            ApplicationName = applicationName;
             ContentRootPath = Path.GetDirectoryName(selfLocation.GetUetLocalLocation(true))!;
             ContentRootFileProvider = null!;
         }

--- a/UET/uet/Commands/Internal/RkmService/RkmServiceCommand.cs
+++ b/UET/uet/Commands/Internal/RkmService/RkmServiceCommand.cs
@@ -44,10 +44,10 @@ namespace UET.Commands.Internal.Rkm
                     {
                         services.AddWindowsService(options =>
                         {
-                            options.ServiceName = "RKM";
+                            options.ServiceName = "rkm";
                         });
                     }
-                    services.AddRkmServiceHelpers(true);
+                    services.AddRkmServiceHelpers(true, "rkm");
                     services.AddHostedService<RKMWorker>();
                 });
             return command;

--- a/UET/uet/Commands/Internal/RkmService/RkmServiceCommand.cs
+++ b/UET/uet/Commands/Internal/RkmService/RkmServiceCommand.cs
@@ -1,11 +1,9 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.WindowsServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.EventLog;
-using Redpoint.Concurrency;
 using Redpoint.KubernetesManager;
 using Redpoint.KubernetesManager.Services;
 using Redpoint.ProgressMonitor;
@@ -21,9 +19,9 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
+using UET.Commands.Cluster;
 using UET.Commands.Internal.RkmService;
 using UET.Commands.Upgrade;
-using UET.Services;
 
 namespace UET.Commands.Internal.Rkm
 {
@@ -49,95 +47,32 @@ namespace UET.Commands.Internal.Rkm
                             options.ServiceName = "RKM";
                         });
                     }
-                    services.AddKubernetesManager();
-                    services.AddSingleton<IRkmVersionProvider, UetRkmVersionProvider>();
-                    services.AddSingleton<IHostApplicationLifetime>(sp => sp.GetRequiredService<RkmHostApplicationLifetime>());
-                    services.AddSingleton<RkmHostApplicationLifetime, RkmHostApplicationLifetime>();
-                    services.AddSingleton<IHostEnvironment, RkmHostEnvironment>();
+                    services.AddRkmServiceHelpers(true);
+                    services.AddHostedService<RKMWorker>();
                 });
             return command;
-        }
-
-        private sealed class RkmHostEnvironment : IHostEnvironment
-        {
-            public RkmHostEnvironment(
-                ISelfLocation selfLocation)
-            {
-                EnvironmentName = "Production";
-                ApplicationName = "RKM";
-                ContentRootPath = Path.GetDirectoryName(selfLocation.GetUetLocalLocation(true))!;
-                ContentRootFileProvider = null!;
-            }
-
-            public string EnvironmentName { get; set; }
-            public string ApplicationName { get; set; }
-            public string ContentRootPath { get; set; }
-            public IFileProvider ContentRootFileProvider { get; set; }
-        }
-
-        private sealed class RkmHostApplicationLifetime : IHostApplicationLifetime, IDisposable
-        {
-            public readonly CancellationTokenSource CtsStarted;
-            public readonly CancellationTokenSource CtsStopping;
-            public readonly CancellationTokenSource CtsStopped;
-            public readonly Gate StopRequestedGate;
-
-            public RkmHostApplicationLifetime()
-            {
-                CtsStarted = new CancellationTokenSource();
-                CtsStopping = new CancellationTokenSource();
-                CtsStopped = new CancellationTokenSource();
-                StopRequestedGate = new Gate();
-            }
-
-            public CancellationToken ApplicationStarted => CtsStarted.Token;
-
-            public CancellationToken ApplicationStopping => CtsStopping.Token;
-
-            public CancellationToken ApplicationStopped => CtsStopped.Token;
-
-            public void StopApplication()
-            {
-                StopRequestedGate.Open();
-            }
-
-            public void Dispose()
-            {
-                ((IDisposable)CtsStarted).Dispose();
-                ((IDisposable)CtsStopping).Dispose();
-                ((IDisposable)CtsStopped).Dispose();
-            }
         }
 
         private sealed class RunRkmServiceCommandInstance : ICommandInstance
         {
             private readonly ILogger<RunRkmServiceCommandInstance> _logger;
-            private readonly Options _options;
-            private readonly RkmHostApplicationLifetime _hostApplicationLifetime;
             private readonly IProgressFactory _progressFactory;
             private readonly IMonitorFactory _monitorFactory;
             private readonly IRkmGlobalRootProvider _rkmGlobalRootProvider;
-            private readonly IReadOnlyList<IHostedService> _hostedServices;
-            private readonly IHostLifetime? _hostLifetime;
+            private readonly IHostedServiceFromExecutable _hostedServiceFromExecutable;
 
             public RunRkmServiceCommandInstance(
                 ILogger<RunRkmServiceCommandInstance> logger,
-                Options options,
-                IEnumerable<IHostedService> hostedServices,
-                RkmHostApplicationLifetime hostApplicationLifetime,
                 IProgressFactory progressFactory,
                 IMonitorFactory monitorFactory,
                 IRkmGlobalRootProvider rkmGlobalRootProvider,
-                IHostLifetime? hostLifetime = null)
+                IHostedServiceFromExecutable hostedServiceFromExecutable)
             {
                 _logger = logger;
-                _options = options;
-                _hostApplicationLifetime = hostApplicationLifetime;
                 _progressFactory = progressFactory;
                 _monitorFactory = monitorFactory;
                 _rkmGlobalRootProvider = rkmGlobalRootProvider;
-                _hostedServices = hostedServices.ToList();
-                _hostLifetime = hostLifetime;
+                _hostedServiceFromExecutable = hostedServiceFromExecutable;
             }
 
             public async Task<int> ExecuteAsync(InvocationContext context)
@@ -192,76 +127,7 @@ namespace UET.Commands.Internal.Rkm
 
                 _logger.LogInformation("RKM is starting...");
 
-                if (OperatingSystem.IsWindows() && WindowsServiceHelpers.IsWindowsService())
-                {
-                    _logger.LogInformation("Waiting for service start...");
-                    await _hostLifetime!.WaitForStartAsync(context.GetCancellationToken());
-                }
-
-                try
-                {
-                    foreach (var hostedService in _hostedServices)
-                    {
-                        _logger.LogInformation($"Starting hosted service '{hostedService.GetType().FullName}'...");
-                        await hostedService.StartAsync(context.GetCancellationToken());
-                        _logger.LogInformation($"Started hosted service '{hostedService.GetType().FullName}'.");
-                    }
-
-                    if (OperatingSystem.IsWindows() && WindowsServiceHelpers.IsWindowsService())
-                    {
-                        // Tells the service lifetime that we have now started. The service
-                        // lifetime will call StopApplication when we should shutdown, which
-                        // will open the gate.
-                        _hostApplicationLifetime.CtsStarted.Cancel();
-                    }
-                    else
-                    {
-                        // Wire up Ctrl-C to request stop.
-                        if (context.GetCancellationToken().IsCancellationRequested)
-                        {
-                            _hostApplicationLifetime.StopRequestedGate.Open();
-                        }
-                        else
-                        {
-                            context.GetCancellationToken().Register(_hostApplicationLifetime.StopRequestedGate.Open);
-                        }
-                    }
-
-                    // Wait until shutdown is requested.
-                    _logger.LogInformation("RKM is waiting for StopRequestedGate to be opened...");
-                    await _hostApplicationLifetime.StopRequestedGate.WaitAsync(CancellationToken.None);
-                    _logger.LogInformation("RKM is now shutting down due to StopRequestedGate being opened.");
-                }
-                finally
-                {
-                    _logger.LogInformation("Shutting down service...");
-
-                    if (OperatingSystem.IsWindows() && WindowsServiceHelpers.IsWindowsService())
-                    {
-                        _hostApplicationLifetime.CtsStopping.Cancel();
-                    }
-
-                    foreach (var hostedService in _hostedServices)
-                    {
-                        _logger.LogInformation($"Stopping hosted service '{hostedService.GetType().FullName}'...");
-                        await hostedService.StopAsync(context.GetCancellationToken());
-                        _logger.LogInformation($"Stopped hosted service '{hostedService.GetType().FullName}'.");
-                    }
-
-                    if (OperatingSystem.IsWindows() && WindowsServiceHelpers.IsWindowsService())
-                    {
-                        using var cts = new CancellationTokenSource(30000);
-                        try
-                        {
-                            await _hostLifetime!.StopAsync(cts.Token);
-                        }
-                        catch
-                        {
-                        }
-                        _hostApplicationLifetime.CtsStopped.Cancel();
-                        _logger.LogInformation("Service has been stopped.");
-                    }
-                }
+                await _hostedServiceFromExecutable.RunHostedServicesAsync(context.GetCancellationToken());
 
                 return 0;
             }

--- a/UET/uet/Commands/Internal/RkmService/UetRkmVersionProvider.cs
+++ b/UET/uet/Commands/Internal/RkmService/UetRkmVersionProvider.cs
@@ -4,13 +4,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UET.Services;
 
 namespace UET.Commands.Internal.RkmService
 {
     class UetRkmVersionProvider : IRkmVersionProvider
     {
+        private readonly ISelfLocation _selfLocation;
+
+        public UetRkmVersionProvider(
+            ISelfLocation selfLocation)
+        {
+            _selfLocation = selfLocation;
+        }
+
         private static Lazy<string> _version = new Lazy<string>(() => RedpointSelfVersion.GetInformationalVersion() ?? "dev");
 
         public string Version => _version.Value;
+
+        public string UetFilePath => _selfLocation.GetUetLocalLocation(true);
     }
 }


### PR DESCRIPTION
This adds a separate `uet cluster run-containerd` command which is responsible for running containerd. It retrieves the containerd manifest from a cache on disk, and connects to `ws://127.0.0.1:8375/containerd`. It is intended that the main RKM service will offer a WebSocket that pushes the manifest out whenever it changes - the main RKM service pulling this information from the cluster controller, which in turn should use Kubernetes as an authoritative version (with an on-disk cache).

The benefit of doing this is that we can allow cluster administrators to change the containerd version on all of the cluster nodes, without manually changing configuration on each machine.

In addition, this command is much more efficient at downloading and extracting containerd and it's dependencies, and starts much faster than the main RKM service currently does.

The main RKM service has not yet been updated to use the new `run-containerd` command yet.