### PR TITLE
Remove downloading containerd in main RKM process

### DIFF
--- a/UET/Redpoint.KubernetesManager/Components/AssetPreparationComponent.cs
+++ b/UET/Redpoint.KubernetesManager/Components/AssetPreparationComponent.cs
@@ -46,9 +46,7 @@
             if (OperatingSystem.IsLinux())
             {
                 // Ensure the assets are downloaded.
-                await _assetManager.EnsureAsset("RKM:Downloads:Containerd:Linux", "containerd.tar.gz", stoppingToken);
                 await _assetManager.EnsureAsset("RKM:Downloads:KubernetesNode:Linux", "kubernetes-node.tar.gz", stoppingToken);
-                await _assetManager.EnsureAsset("RKM:Downloads:Runc:Linux", "runc", stoppingToken);
                 await _assetManager.EnsureAsset("RKM:Downloads:CniPlugins:Linux", "cni-plugins.tar.gz", stoppingToken);
                 if (context.Role == RoleType.Controller)
                 {
@@ -58,22 +56,8 @@
                 }
 
                 // Extract the assets.
-                await _assetManager.ExtractAsset("containerd.tar.gz", Path.Combine(_pathProvider.RKMRoot, "containerd"), stoppingToken);
-                Directory.CreateDirectory(Path.Combine(_pathProvider.RKMRoot, "containerd-state"));
                 await _assetManager.ExtractAsset("kubernetes-node.tar.gz", Path.Combine(_pathProvider.RKMRoot, "kubernetes-node"), stoppingToken);
                 await _assetManager.ExtractAsset("cni-plugins.tar.gz", Path.Combine(_pathProvider.RKMRoot, "cni-plugins"), stoppingToken);
-                if (!File.Exists(Path.Combine(_pathProvider.RKMRoot, "runc", "runc")) ||
-                    !File.Exists(Path.Combine(_pathProvider.RKMRoot, "runc", "runc.version")) ||
-                    File.ReadAllText(Path.Combine(_pathProvider.RKMRoot, "runc", "runc.version")) != _pathProvider.RKMVersion)
-                {
-                    Directory.CreateDirectory(Path.Combine(_pathProvider.RKMRoot, "runc"));
-                    File.Copy(
-                        Path.Combine(_pathProvider.RKMRoot, "assets", _pathProvider.RKMVersion, "runc"),
-                        Path.Combine(_pathProvider.RKMRoot, "runc", "runc"),
-                        true);
-                    chmod(Path.Combine(_pathProvider.RKMRoot, "runc", "runc"), 0x100 | 0x80 | 0x40 | 0x20 | 0x8 | 0x4 | 0x1);
-                    File.WriteAllText(Path.Combine(_pathProvider.RKMRoot, "runc", "runc.version"), _pathProvider.RKMVersion);
-                }
 
                 // On the controller, extract the controller-specific assets.
                 if (context.Role == RoleType.Controller)
@@ -131,9 +115,7 @@ exit $?
                 if (context.Role == RoleType.Controller)
                 {
                     // Get the assets needed to run kubelet in WSL.
-                    await _assetManager.EnsureAsset("RKM:Downloads:Containerd:Linux", "wsl-containerd.tar.gz", stoppingToken);
                     await _assetManager.EnsureAsset("RKM:Downloads:KubernetesNode:Linux", "wsl-kubernetes-node.tar.gz", stoppingToken);
-                    await _assetManager.EnsureAsset("RKM:Downloads:Runc:Linux", "wsl-runc", stoppingToken);
                     await _assetManager.EnsureAsset("RKM:Downloads:CniPlugins:Linux", "wsl-cni-plugins.tar.gz", stoppingToken);
                     // Get the assets needed to run the Kubernetes API server and etcd in WSL.
                     await _assetManager.EnsureAsset("RKM:Downloads:KubernetesServer:Linux", "kubernetes-server.tar.gz", stoppingToken);
@@ -144,16 +126,7 @@ exit $?
                 }
 
                 // Extract the assets.
-                await _assetManager.ExtractAsset("containerd.tar.gz", Path.Combine(_pathProvider.RKMRoot, "containerd"), stoppingToken);
-                Directory.CreateDirectory(Path.Combine(_pathProvider.RKMRoot, "containerd-state"));
                 await _assetManager.ExtractAsset("kubernetes-node.tar.gz", Path.Combine(_pathProvider.RKMRoot, "kubernetes-node"), stoppingToken);
-                await _assetManager.ExtractAsset("redpoint-containerd-for-win11.zip", Path.Combine(_pathProvider.RKMRoot, "containerd-redpoint"), stoppingToken);
-
-                // Overwrite the shipped containerd with the Redpoint patched version so that LTSC2022 images work on Windows 11.
-                File.Copy(
-                    Path.Combine(_pathProvider.RKMRoot, "containerd-redpoint", "containerd.exe"),
-                    Path.Combine(_pathProvider.RKMRoot, "containerd", "bin", "containerd.exe"),
-                    true);
 
                 // On the controller, extract the controller-specific assets.
                 if (context.Role == RoleType.Controller)

--- a/UET/Redpoint.KubernetesManager/Services/DefaultAssetConfiguration.cs
+++ b/UET/Redpoint.KubernetesManager/Services/DefaultAssetConfiguration.cs
@@ -9,8 +9,6 @@ namespace Redpoint.KubernetesManager.Services
     internal class DefaultAssetConfiguration : IAssetConfiguration
     {
         private const string _kubernetesVersion = "1.26.1";
-        private const string _containerdVersion = "1.6.18";
-        private const string _runcVersion = "1.3.0";
         private const string _etcdVersion = "3.6.4";
         private const string _cniPluginsVersion = "0.8.7";
         private const string _helmVersion = "3.17.3";
@@ -20,12 +18,6 @@ namespace Redpoint.KubernetesManager.Services
             { "KubernetesNode:Linux", $"https://dl.k8s.io/v{_kubernetesVersion}/kubernetes-node-linux-amd64.tar.gz" },
             { "KubernetesNode:Windows", $"https://dl.k8s.io/v{_kubernetesVersion}/kubernetes-node-windows-amd64.tar.gz" },
             { "KubernetesServer:Linux", $"https://dl.k8s.io/v{_kubernetesVersion}/kubernetes-server-linux-amd64.tar.gz" },
-            { "Containerd:Linux", $"https://github.com/containerd/containerd/releases/download/v{_containerdVersion}/containerd-{_containerdVersion}-linux-amd64.tar.gz" },
-            { "Containerd:Windows", $"https://github.com/containerd/containerd/releases/download/v{_containerdVersion}/containerd-{_containerdVersion}-windows-amd64.tar.gz" },
-            // A temporary patched version of containerd that works on Windows 11 until the following pull request is
-            // in a containerd release: https://github.com/containerd/containerd/pull/8137
-            { "ContainerdForWin11:Windows", $"https://dl-public.redpoint.games/file/dl-public-redpoint-games/redpoint-containerd-for-win11-{_containerdVersion}.zip" },
-            { "Runc:Linux", $"https://github.com/opencontainers/runc/releases/download/v{_runcVersion}/runc.amd64" },
             { "Etcd:Linux", $"https://github.com/etcd-io/etcd/releases/download/v{_etcdVersion}/etcd-v{_etcdVersion}-linux-amd64.tar.gz" },
             { "CniPlugins:Linux", $"https://github.com/containernetworking/plugins/releases/download/v{_cniPluginsVersion}/cni-plugins-linux-amd64-v{_cniPluginsVersion}.tgz" },
             { "UbuntuWSL:Windows", $"https://wslstorestorage.blob.core.windows.net/wslblob/CanonicalGroupLimited.UbuntuonWindows_2004.2021.825.0.AppxBundle" },


### PR DESCRIPTION
The 'run-containerd' command now downloads containerd and runc as needed.