### PR TITLE
Terminate existing dockerd process before starting dockerd container

### DIFF
--- a/UET/Lib/Helm/rkm/templates/dockerd-windows/dockerd.yaml
+++ b/UET/Lib/Helm/rkm/templates/dockerd-windows/dockerd.yaml
@@ -14,6 +14,10 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}
       rkm.redpoint.games/component: dockerd-windows
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "100%"
   template:
     metadata:
       labels:
@@ -31,6 +35,15 @@ spec:
           runAsUserName: "NT AUTHORITY\\SYSTEM"
       hostNetwork: true
       automountServiceAccountToken: false
+      initContainers:
+      - name: kill-existing-process
+        image: {{ printf "ghcr.io/redpointgames/uet/uet:%s-hostprocess" .Values.versions.rkm | quote }}
+        command:
+        - .\pwsh\pwsh.exe
+        - -ExecutionPolicy
+        - Bypass
+        - -Command
+        - "C:\\Windows\\system32\\taskkill.exe /f /im dockerd.exe; if (Test-Path C:\\ProgramData\\docker\\docker.pid) { Remove-Item -Force -Path C:\\ProgramData\\docker\\docker.pid }; exit 0"
       containers:
       - name: dockerd
         image: ghcr.io/redpointgames/uet/dockerd-hostprocess:latest


### PR DESCRIPTION
This fixes a CrashLoopBackoff scenario where dockerd detects an old daemon and won't start.