### PR TITLE
Add RunAsTrustedInstaller to ProcessExecutor library

### DIFF
--- a/UET/Redpoint.ProcessExecution.Tests/Redpoint.ProcessExecution.Tests.csproj
+++ b/UET/Redpoint.ProcessExecution.Tests/Redpoint.ProcessExecution.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Redpoint.ProcessExecution\Redpoint.ProcessExecution.csproj" />
+    <ProjectReference Include="..\Redpoint.ServiceControl\Redpoint.ServiceControl.csproj" />
   </ItemGroup>
 
 </Project>

--- a/UET/Redpoint.ProcessExecution.Tests/TrustedInstallerTests.cs
+++ b/UET/Redpoint.ProcessExecution.Tests/TrustedInstallerTests.cs
@@ -1,0 +1,58 @@
+﻿namespace Redpoint.ProcessExecution.Tests
+{
+    using Microsoft.Extensions.DependencyInjection;
+    using Redpoint.ProcessExecution.Windows;
+    using Redpoint.ServiceControl;
+    using System.Runtime.Versioning;
+    using System.Security.Principal;
+    using System.Text;
+    using Xunit;
+
+    public class TrustedInstallerTests
+    {
+        [SkippableFact]
+        [SupportedOSPlatform("windows6.0.6000")]
+        public async Task CanExecuteAsTrustedInstallerAsync()
+        {
+            Skip.IfNot(OperatingSystem.IsWindows());
+
+            var isAdministrator = new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
+            Skip.IfNot(isAdministrator);
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddProcessExecution();
+            services.AddServiceControl();
+            var sp = services.BuildServiceProvider();
+
+            var executor = sp.GetRequiredService<IProcessExecutor>();
+            var serviceControl = sp.GetRequiredService<IServiceControl>();
+
+            Assert.IsType<WindowsProcessExecutor>(executor);
+
+            await serviceControl.StartService(
+                "TrustedInstaller",
+                CancellationToken.None);
+
+            var authorityPath = Path.GetTempFileName();
+
+            var exitCode = await executor.ExecuteAsync(
+                new ProcessSpecification
+                {
+                    FilePath = @"C:\Windows\system32\cmd.exe",
+                    Arguments =
+                    [
+                        "/C",
+                        $@"C:\Windows\system32\whoami.exe > {authorityPath}",
+                    ],
+                    RunAsTrustedInstaller = true,
+                },
+                CaptureSpecification.Passthrough,
+                CancellationToken.None).ConfigureAwait(false);
+
+            var authority = File.ReadAllText(authorityPath);
+            Assert.Equal(0, exitCode);
+            Assert.Equal("nt authority\\system", authority.Trim(), ignoreCase: true);
+        }
+    }
+}

--- a/UET/Redpoint.ProcessExecution/NativeMethods.txt
+++ b/UET/Redpoint.ProcessExecution/NativeMethods.txt
@@ -9,6 +9,7 @@ GetConsoleCP
 GetConsoleOutputCP
 GetExitCodeProcess
 STILL_ACTIVE
+STATUS_SUCCESS
 TerminateProcess
 NtQueryInformationProcess
 PROCESS_BASIC_INFORMATION
@@ -26,3 +27,19 @@ GetExitCodeThread
 CloseHandle
 VirtualFreeEx
 INFINITE
+STARTUPINFOEXW
+InitializeProcThreadAttributeList
+UpdateProcThreadAttribute
+DeleteProcThreadAttributeList
+PROC_THREAD_ATTRIBUTE_PARENT_PROCESS
+PROC_THREAD_ATTRIBUTE_INPUT
+OpenSCManager
+SC_MANAGER_CONNECT
+CloseServiceHandle
+OpenService
+SERVICE_QUERY_STATUS
+SERVICE_STATUS_PROCESS
+QueryServiceStatusEx
+SC_STATUS_TYPE
+CLIENT_ID
+STATUS_DLL_INIT_FAILED

--- a/UET/Redpoint.ProcessExecution/ProcessExecutionServiceExtensions.cs
+++ b/UET/Redpoint.ProcessExecution/ProcessExecutionServiceExtensions.cs
@@ -13,7 +13,7 @@
         /// </summary>
         public static void AddProcessExecution(this IServiceCollection services)
         {
-            if (OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
+            if (OperatingSystem.IsWindowsVersionAtLeast(6, 0, 6000))
             {
                 services.AddSingleton<DefaultProcessExecutor, DefaultProcessExecutor>();
                 services.AddSingleton<IProcessExecutor, WindowsProcessExecutor>();

--- a/UET/Redpoint.ProcessExecution/ProcessSpecification.cs
+++ b/UET/Redpoint.ProcessExecution/ProcessSpecification.cs
@@ -17,5 +17,11 @@
         /// </summary>
         [SupportedOSPlatform("windows")]
         public IReadOnlyDictionary<char, string>? PerProcessDriveMappings { get; set; }
+
+        /// <summary>
+        /// If set to true, the process will be run underneath with TrustedInstaller privileges. The "Windows Module Installer" service must have been started prior to using this option.
+        /// </summary>
+        [SupportedOSPlatform("windows")]
+        public bool RunAsTrustedInstaller { get; set; }
     }
 }

--- a/UET/Redpoint.ProcessExecution/Windows/Ntdll/NtdllPInvoke.cs
+++ b/UET/Redpoint.ProcessExecution/Windows/Ntdll/NtdllPInvoke.cs
@@ -1,9 +1,11 @@
 ﻿namespace Redpoint.ProcessExecution.Windows.Ntdll
 {
-    using System.Runtime.InteropServices;
-    using System.Runtime.Versioning;
     using global::Windows.Win32.Foundation;
     using global::Windows.Win32.System.Threading;
+    using global::Windows.Win32.System.WindowsProgramming;
+    using System.Net.NetworkInformation;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Versioning;
 
     [SupportedOSPlatform("windows")]
     internal static unsafe class NtdllPInvoke
@@ -39,5 +41,21 @@
             ACCESS_MASK DesiredAccess,
             OBJECT_ATTRIBUTES* ObjectAttributes,
             UNICODE_STRING* LinkTarget);
+
+        [DllImport("ntdll.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern unsafe NTSTATUS NtOpenProcess(
+            nint* ProcessHandle,
+            ACCESS_MASK DesiredAccess,
+            OBJECT_ATTRIBUTES* ObjectAttributes,
+            CLIENT_ID* ClientId);
+
+        [DllImport("ntdll.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern unsafe NTSTATUS NtClose(nint handle);
+
+        [DllImport("ntdll.dll")]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern unsafe int RtlNtStatusToDosError(int status);
     }
 }

--- a/UET/Redpoint.ProcessExecution/Windows/RunAsTrustedInstallerFailedException.cs
+++ b/UET/Redpoint.ProcessExecution/Windows/RunAsTrustedInstallerFailedException.cs
@@ -1,0 +1,11 @@
+﻿namespace Redpoint.ProcessExecution.Windows
+{
+    using System;
+
+    public class RunAsTrustedInstallerFailedException : Exception
+    {
+        public RunAsTrustedInstallerFailedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/UET/Redpoint.ProcessExecution/Windows/WindowsTrustedInstaller.cs
+++ b/UET/Redpoint.ProcessExecution/Windows/WindowsTrustedInstaller.cs
@@ -1,0 +1,165 @@
+﻿namespace Redpoint.ProcessExecution.Windows
+{
+    using global::Windows.Win32.Foundation;
+    using global::Windows.Win32.Security;
+    using global::Windows.Win32.System.Console;
+    using global::Windows.Win32.System.Services;
+    using global::Windows.Win32.System.Threading;
+    using global::Windows.Win32.System.WindowsProgramming;
+    using Redpoint.ProcessExecution.Windows.Ntdll;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net.NetworkInformation;
+    using System.Runtime.InteropServices;
+    using System.Runtime.Intrinsics.Arm;
+    using System.Runtime.Versioning;
+    using System.Text;
+    using System.Threading.Tasks;
+    using PInvoke = global::Windows.Win32.PInvoke;
+
+    [SupportedOSPlatform("windows6.0.6000")]
+    internal class WindowsTrustedInstaller
+    {
+        internal class NtProcessSafeHandle : SafeHandle
+        {
+            public NtProcessSafeHandle(nint ntProcess)
+                : base(nint.Zero, true)
+            {
+                handle = ntProcess;
+            }
+
+            public override bool IsInvalid => handle == nint.Zero;
+
+            protected override bool ReleaseHandle()
+            {
+                if (handle != nint.Zero)
+                {
+                    NtdllPInvoke.NtClose(handle);
+                    handle = nint.Zero;
+                }
+                return true;
+            }
+        }
+
+        internal unsafe static NtProcessSafeHandle GetTrustedInstallerParentProcess()
+        {
+            // Get the process ID for the service.
+            uint trustedInstallerProcessId = 0;
+            SC_HANDLE scm = PInvoke.OpenSCManager(
+                (PCWSTR)null,
+                (PCWSTR)null,
+                PInvoke.SC_MANAGER_CONNECT);
+            if (scm.Value == 0)
+            {
+                // Can't open the service manager.
+                throw new RunAsTrustedInstallerFailedException("Unable to access the Service Control Manager.");
+            }
+            try
+            {
+                SC_HANDLE service = PInvoke.OpenService(
+                    scm,
+                    "TrustedInstaller",
+                    PInvoke.SERVICE_QUERY_STATUS);
+                if (service.Value == 0)
+                {
+                    // Can't open service.
+                    throw new RunAsTrustedInstallerFailedException("Unable to access the 'TrustedInstaller' service on the Service Control Manager.");
+                }
+                try
+                {
+                    byte* serviceProcessInfo = null;
+                    uint serviceProcessInfoSize = 0;
+                    uint serviceProcessInfoBytesNeeded = 0;
+                    var querySizeResult = PInvoke.QueryServiceStatusEx(
+                        service,
+                        SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+                        serviceProcessInfo,
+                        serviceProcessInfoSize,
+                        &serviceProcessInfoBytesNeeded);
+                    if (!querySizeResult && (WIN32_ERROR)Marshal.GetLastWin32Error() != WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER)
+                    {
+                        // Can't query process info size.
+                        var errorMessage = (WIN32_ERROR)Marshal.GetLastWin32Error() switch
+                        {
+                            WIN32_ERROR.ERROR_INVALID_HANDLE => "The handle is invalid.",
+                            WIN32_ERROR.ERROR_ACCESS_DENIED => "The handle does not have the SERVICE_QUERY_STATUS access right.",
+                            WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER => "The buffer is too small for the SERVICE_STATUS_PROCESS structure. Nothing was written to the structure.",
+                            WIN32_ERROR.ERROR_INVALID_PARAMETER => "The cbSize member of SERVICE_STATUS_PROCESS is not valid.",
+                            WIN32_ERROR.ERROR_INVALID_LEVEL => "The InfoLevel parameter contains an unsupported value.",
+                            WIN32_ERROR.ERROR_SHUTDOWN_IN_PROGRESS => "The system is shutting down; this function cannot be called.",
+                            _ => "Unknown error."
+                        };
+                        throw new RunAsTrustedInstallerFailedException($"Unable to query the size needed to store the status of the 'TrustedInstaller' service; got Win32 error: {errorMessage}");
+                    }
+
+                    serviceProcessInfo = (byte*)Marshal.AllocHGlobal((int)serviceProcessInfoBytesNeeded);
+                    serviceProcessInfoSize = serviceProcessInfoBytesNeeded;
+                    try
+                    {
+                        if (!PInvoke.QueryServiceStatusEx(
+                            service,
+                            SC_STATUS_TYPE.SC_STATUS_PROCESS_INFO,
+                            serviceProcessInfo,
+                            serviceProcessInfoSize,
+                            &serviceProcessInfoBytesNeeded))
+                        {
+                            // Can't query service.
+                            var errorMessage = (WIN32_ERROR)Marshal.GetLastWin32Error() switch
+                            {
+                                WIN32_ERROR.ERROR_INVALID_HANDLE => "The handle is invalid.",
+                                WIN32_ERROR.ERROR_ACCESS_DENIED => "The handle does not have the SERVICE_QUERY_STATUS access right.",
+                                WIN32_ERROR.ERROR_INSUFFICIENT_BUFFER => "The buffer is too small for the SERVICE_STATUS_PROCESS structure. Nothing was written to the structure.",
+                                WIN32_ERROR.ERROR_INVALID_PARAMETER => "The cbSize member of SERVICE_STATUS_PROCESS is not valid.",
+                                WIN32_ERROR.ERROR_INVALID_LEVEL => "The InfoLevel parameter contains an unsupported value.",
+                                WIN32_ERROR.ERROR_SHUTDOWN_IN_PROGRESS => "The system is shutting down; this function cannot be called.",
+                                _ => "Unknown error."
+                            };
+
+                            throw new RunAsTrustedInstallerFailedException($"Unable to query the status of the 'TrustedInstaller' service; got Win32 error: {errorMessage}");
+                        }
+
+                        SERVICE_STATUS_PROCESS* serviceProcessInfoCasted = (SERVICE_STATUS_PROCESS*)serviceProcessInfo;
+                        trustedInstallerProcessId = serviceProcessInfoCasted->dwProcessId;
+                    }
+                    finally
+                    {
+                        Marshal.FreeHGlobal((nint)serviceProcessInfo);
+                    }
+                }
+                finally
+                {
+                    PInvoke.CloseServiceHandle(service);
+                }
+            }
+            finally
+            {
+                PInvoke.CloseServiceHandle(scm);
+            }
+            if (trustedInstallerProcessId == 0)
+            {
+                // Service isn't running or process ID not available.
+                throw new RunAsTrustedInstallerFailedException("Unable to get the process ID of the 'TrustedInstaller' service.");
+            }
+
+            CLIENT_ID clientId;
+            clientId.UniqueThread = HANDLE.Null;
+            clientId.UniqueProcess = new HANDLE((nint)trustedInstallerProcessId);
+
+            OBJECT_ATTRIBUTES objectAttributes;
+
+            nint ntProcess = nint.Zero;
+            var openProcessResult = NtdllPInvoke.NtOpenProcess(
+                &ntProcess,
+                ACCESS_MASK.MAXIMUM_ALLOWED,
+                &objectAttributes,
+                &clientId);
+            if (openProcessResult != NTSTATUS.STATUS_SUCCESS)
+            {
+                throw new RunAsTrustedInstallerFailedException($"Unable to open the 'TrustedInstaller' process with ID {trustedInstallerProcessId}; got NTRESULT {(openProcessResult.Value):X}.");
+            }
+
+            return new NtProcessSafeHandle(ntProcess);
+        }
+    }
+}


### PR DESCRIPTION
This is to support RKM automatically applying the `vfp_forward` patch to the registry when needed.