### PR TITLE
Request non-concurrent target workspace if engine is non-concurrent

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline.Executors.GitLab/GitLabBuildExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Executors.GitLab/GitLabBuildExecutor.cs
@@ -34,6 +34,7 @@
             BuildSpecification buildSpecification,
             BuildServerPipeline buildServerPipeline)
         {
+            ArgumentNullException.ThrowIfNull(buildSpecification);
             ArgumentNullException.ThrowIfNull(buildServerPipeline);
 
             if (string.IsNullOrWhiteSpace(_buildServerOutputFilePath))
@@ -67,11 +68,27 @@
 
                 if (sourceJob.Agent.Platform == BuildServerJobPlatform.Windows)
                 {
-                    job.Tags = new List<string> { "buildgraph-windows" };
+                    if (buildSpecification.Engine.IsNonConcurrent &&
+                        System.Environment.GetEnvironmentVariable("UET_USE_EXCLUSIVE_NODES_FOR_NONCONCURRENT_ENGINE") == "1")
+                    {
+                        job.Tags = new List<string> { "buildgraph-exclusive-windows" };
+                    }
+                    else
+                    {
+                        job.Tags = new List<string> { "buildgraph-windows" };
+                    }
                 }
                 else if (sourceJob.Agent.Platform == BuildServerJobPlatform.Mac)
                 {
-                    job.Tags = new List<string> { "buildgraph-mac" };
+                    if (buildSpecification.Engine.IsNonConcurrent &&
+                        System.Environment.GetEnvironmentVariable("UET_USE_EXCLUSIVE_NODES_FOR_NONCONCURRENT_ENGINE") == "1")
+                    {
+                        job.Tags = new List<string> { "buildgraph-exclusive-mac" };
+                    }
+                    else
+                    {
+                        job.Tags = new List<string> { "buildgraph-mac" };
+                    }
                 }
                 else if (sourceJob.Agent.Platform == BuildServerJobPlatform.Meta)
                 {

--- a/UET/Redpoint.Uet.BuildPipeline/Executors/BuildEngineSpecification.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/Executors/BuildEngineSpecification.cs
@@ -172,5 +172,32 @@
                 throw new NotSupportedException();
             }
         }
+
+        public bool IsNonConcurrent
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(_engineVersion))
+                {
+                    return true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(_enginePath))
+                {
+                    return true;
+                }
+
+                if (!string.IsNullOrWhiteSpace(_gitUrl))
+                {
+                    if (_queryString != null &&
+                        _queryString["concurrent"] == "false")
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
This optimizes workspace allocation on GitLab when the engine being used doesn't support or allow concurrency.

It also adds a new environment variable `UET_USE_EXCLUSIVE_NODES_FOR_NONCONCURRENT_ENGINE` which will request tags 'buildgraph-exclusive-windows' and 'buildgraph-exclusive-mac' (GitLab runners with this tag should be configured to only run one job at a time per node). This ensures that our concurrent GitLab runners don't idle waiting for an engine or target workspace to unlock due to non-concurrency.