### PR TITLE
Remove existing index.lock files when updating Git repositories

### DIFF
--- a/UET/Redpoint.Uet.Workspace/Redpoint.Uet.Workspace.csproj
+++ b/UET/Redpoint.Uet.Workspace/Redpoint.Uet.Workspace.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Redpoint.GrpcPipes\Redpoint.GrpcPipes.csproj" />
+    <ProjectReference Include="..\Redpoint.Windows.HandleManagement\Redpoint.Windows.HandleManagement.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UET/uet/Commands/Internal/RegisterGitLabRunner/RegisterGitLabRunnerCommand.cs
+++ b/UET/uet/Commands/Internal/RegisterGitLabRunner/RegisterGitLabRunnerCommand.cs
@@ -60,7 +60,7 @@
                     _logger.LogError("Environment variable 'UET_GITLAB_BASE_URL' was invalid.");
                     return 1;
                 }
-                if (string.IsNullOrWhiteSpace(baseUrl))
+                if (string.IsNullOrWhiteSpace(personalAccessToken))
                 {
                     _logger.LogError("Environment variable 'UET_GITLAB_PERSONAL_ACCESS_TOKEN' was invalid.");
                     return 1;


### PR DESCRIPTION
On Windows, if running with Administrator permissions, we'll check if an existing process has the index.lock file open (in case there is a Git process running in the background that is unsafe to terminate). Otherwise, we just delete it.