### PR TITLE
Symbolically link target workspace into engine for builds with source engines

### DIFF
--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/IBuildGraphExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/IBuildGraphExecutor.cs
@@ -15,8 +15,8 @@
             CancellationToken cancellationToken);
 
         Task<int> ExecuteGraphNodeAsync(
-            string enginePath,
-            string buildGraphRepositoryRootPath,
+            string engineWorkspacePath,
+            string targetWorkspacePath,
             string uetPath,
             string artifactExportPath,
             BuildGraphScriptSpecification buildGraphScript,
@@ -32,8 +32,8 @@
             CancellationToken cancellationToken);
 
         Task<BuildGraphExport> GenerateGraphAsync(
-            string enginePath,
-            string buildGraphRepositoryRootPath,
+            string engineWorkspacePath,
+            string targetWorkspacePath,
             string uetPath,
             string artifactExportPath,
             BuildGraphScriptSpecification buildGraphScript,


### PR DESCRIPTION
In order to get editor binaries to be correctly staged to shared storage when building a project with a source-based engine, we need to symbolically link the target workspace into the engine workspace, and set the engine workspace as the BuildGraph project root.