### PR TITLE
Ensure React and OpenAPI document generation use exactly the same JSON options

### DIFF
--- a/UET/Lib/Redpoint.ThirdParty.React.AspNet.Middleware/MvcJsonSerializerOptionsProvider.cs
+++ b/UET/Lib/Redpoint.ThirdParty.React.AspNet.Middleware/MvcJsonSerializerOptionsProvider.cs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+
+namespace React.AspNet
+{
+    internal class MvcJsonSerializerOptionsProvider : IJsonSerializerOptionsProvider
+    {
+        private readonly IOptions<JsonOptions> _jsonOptions;
+
+        public MvcJsonSerializerOptionsProvider(IOptions<JsonOptions> jsonOptions)
+        {
+            _jsonOptions = jsonOptions;
+        }
+
+        public JsonSerializerOptions Options => _jsonOptions.Value.JsonSerializerOptions;
+    }
+}

--- a/UET/Lib/Redpoint.ThirdParty.React.AspNet.Middleware/ReactServiceCollectionExtensions.cs
+++ b/UET/Lib/Redpoint.ThirdParty.React.AspNet.Middleware/ReactServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ namespace React.AspNet
             services.AddSingleton<IFileSystem, AspNetFileSystem>();
             services.AddSingleton<ICache, MemoryFileCacheCore>();
 
+            services.AddSingleton<IJsonSerializerOptionsProvider, MvcJsonSerializerOptionsProvider>();
+
             return services;
         }
     }

--- a/UET/Lib/Redpoint.ThirdParty.React.Core/IJsonSerializerOptionsProvider.cs
+++ b/UET/Lib/Redpoint.ThirdParty.React.Core/IJsonSerializerOptionsProvider.cs
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+using System.Text.Json;
+
+namespace React
+{
+    /// <summary>
+    /// A required interface that provides the <see cref="JsonSerializerOptions"/> that
+    /// will be used for serialization. This is required so that the SSR and MVC serialize
+    /// JSON in exactly the same way.
+    /// </summary>
+    public interface IJsonSerializerOptionsProvider
+    {
+        /// <summary>
+        /// Provides the JSON options.
+        /// </summary>
+        public JsonSerializerOptions Options { get; }
+    }
+}

--- a/UET/Lib/Redpoint.ThirdParty.React.Core/IReactSiteConfiguration.cs
+++ b/UET/Lib/Redpoint.ThirdParty.React.Core/IReactSiteConfiguration.cs
@@ -62,19 +62,9 @@ namespace React
         IReactSiteConfiguration SetReuseJavaScriptEngines(bool value);
 
         /// <summary>
-        /// Gets or sets the configuration for JSON serializer.
+        /// Gets the configuration for JSON serializer.
         /// </summary>
-        JsonSerializerOptions JsonSerializerSettings { get; set; }
-
-        /// <summary>
-        /// Sets the configuration for json serializer.
-        /// </summary>
-        /// <remarks>
-        /// This confiquration is used when component initialization script
-        /// is being generated server-side.
-        /// </remarks>
-        /// <param name="settings">The settings.</param>
-        IReactSiteConfiguration SetJsonSerializerSettings(JsonSerializerOptions settings);
+        JsonSerializerOptions JsonSerializerSettings { get; }
 
         /// <summary>
         /// Gets or sets the number of engines to initially start when a pool is created.

--- a/UET/Lib/Redpoint.ThirdParty.React.Core/Redpoint.ThirdParty.React.Core.csproj
+++ b/UET/Lib/Redpoint.ThirdParty.React.Core/Redpoint.ThirdParty.React.Core.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Core" />
     <PackageReference Include="JSPool" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/UET/Redpoint.CloudFramework.Tests/React/ReactTests.cs
+++ b/UET/Redpoint.CloudFramework.Tests/React/ReactTests.cs
@@ -2,36 +2,76 @@
 {
     using global::React;
     using global::React.AspNet;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ApplicationParts;
+    using Microsoft.AspNetCore.Mvc.Controllers;
+    using Microsoft.AspNetCore.Routing;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.FileProviders;
+    using Microsoft.OpenApi.Any;
+    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi.Writers;
     using React;
+    using Redpoint.CloudFramework.OpenApi;
+    using Swashbuckle.AspNetCore.Swagger;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Text.Json;
+    using System.Text.Json.Serialization;
     using System.Threading.Tasks;
     using Xunit;
 
+    public enum TestEnum
+    {
+        Test,
+        AnotherCamelCase,
+    }
+
+    public class TestClass
+    {
+        public TestEnum EnumCamelCase { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet, Api, Route("/api/v1/test")]
+        public TestClass Test()
+        {
+            return new TestClass
+            {
+                EnumCamelCase = TestEnum.AnotherCamelCase
+            };
+        }
+    }
+
     public class ReactTests
     {
-        public enum TestEnum
-        {
-            Test,
-            AnotherCamelCase,
-        }
-
-        public class TestClass
-        {
-            public TestEnum EnumCamelCase { get; set; }
-        }
-
         [Fact]
         public void TestJsonEncoding()
         {
-            var services = new ServiceCollection();
-            services.AddReact();
+            var builder = WebApplication.CreateBuilder([]);
 
-            var sp = services.BuildServiceProvider();
+            builder.Services.AddLogging();
+            builder.Services.AddControllersWithViews()
+                .AddControllersAsServices()
+                .AddJsonOptionsForSwaggerReactApp();
+
+            builder.Services.AddReact();
+            builder.Services.AddSwaggerGenForReactApp();
+
+            var app = builder.Build();
+            app.UseRouting();
+            app.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Home}/{action=Index}/{id?}");
+
+            var sp = app.Services;
             var siteConfiguration = sp.GetRequiredService<IReactSiteConfiguration>();
 
             var encoded = JsonSerializer.Serialize(
@@ -43,6 +83,90 @@
             Assert.Equal(
                 @"{""enumCamelCase"":""anotherCamelCase""}",
                 encoded);
+        }
+
+        private class TestWebHostEnvironment : IWebHostEnvironment
+        {
+            public string WebRootPath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public IFileProvider WebRootFileProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string ApplicationName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public IFileProvider ContentRootFileProvider { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string ContentRootPath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string EnvironmentName { get => "Development"; set => throw new NotImplementedException(); }
+        }
+
+        [Fact]
+        public void TestOpenApiGeneration()
+        {
+            var builder = WebApplication.CreateBuilder([]);
+
+            builder.Services.AddLogging();
+            builder.Services.AddControllersWithViews()
+                .AddControllersAsServices()
+                .AddJsonOptionsForSwaggerReactApp();
+
+            builder.Services.AddReact();
+            builder.Services.AddSwaggerGenForReactApp();
+
+            var app = builder.Build();
+            app.UseRouting();
+            app.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Home}/{action=Index}/{id?}");
+
+            var sp = app.Services;
+            var swaggerProvider = sp.GetRequiredService<ISwaggerProvider>();
+
+            _ = sp.GetRequiredService<TestController>();
+
+            var partManager = sp.GetRequiredService<ApplicationPartManager>();
+            var applicationParts = partManager.ApplicationParts.Select(x => x.Name);
+            var controllerFeature = new ControllerFeature();
+            partManager.PopulateFeature(controllerFeature);
+            var controllers = controllerFeature.Controllers.Select(x => x.Name);
+            Console.WriteLine($"Found the following application parts: '{string.Join(", ", applicationParts)}' with the following controllers: '{string.Join(", ", controllers)}'");
+
+            var endpointSources = sp.GetServices<EndpointDataSource>().ToList();
+            Console.WriteLine($"Found {endpointSources.Count} endpoint sources.");
+            foreach (var endpointSource in endpointSources)
+            {
+                Console.WriteLine($"  {endpointSource.Endpoints.Count} endpoints:");
+                foreach (var endpoint in endpointSource.Endpoints.OfType<RouteEndpoint>())
+                {
+                    Console.WriteLine($"    /{endpoint.RoutePattern.RawText?.TrimStart('/')}");
+                }
+            }
+
+            var swagger = swaggerProvider.GetSwagger(
+                documentName: "v1",
+                host: null,
+                basePath: null);
+            Assert.NotNull(swagger);
+
+            using (var textWriter = new StringWriter(CultureInfo.InvariantCulture))
+            {
+                var jsonWriter = new OpenApiJsonWriter(textWriter);
+
+                swagger.SerializeAsV3(jsonWriter);
+
+                Console.WriteLine(textWriter.ToString());
+            }
+
+            Assert.NotEmpty(swagger.Paths);
+            var testPath = Assert.Contains("/api/v1/test", swagger.Paths);
+            var testGetPath = Assert.Contains(OperationType.Get, testPath.Operations);
+            Assert.Equal("Test", testGetPath.OperationId);
+
+            Assert.NotEmpty(swagger.Components.Schemas);
+
+            var testEnumSchema = Assert.Contains("TestEnum", swagger.Components.Schemas);
+            Assert.NotEmpty(testEnumSchema.Enum);
+            Assert.All(testEnumSchema.Enum, x => Assert.IsType<OpenApiString>(x));
+
+            var enumValues = testEnumSchema.Enum.Cast<OpenApiString>().Select(x => x.Value).ToList();
+            Assert.Equal(2, enumValues.Count);
+            Assert.Equal("test", enumValues[0]);
+            Assert.Equal("anotherCamelCase", enumValues[1]);
         }
     }
 }

--- a/UET/Redpoint.CloudFramework/OpenApi/JsonOptionsNotConfiguredException.cs
+++ b/UET/Redpoint.CloudFramework/OpenApi/JsonOptionsNotConfiguredException.cs
@@ -1,0 +1,12 @@
+﻿namespace Redpoint.CloudFramework.OpenApi
+{
+    using System;
+
+    public class JsonOptionsNotConfiguredException : Exception
+    {
+        public JsonOptionsNotConfiguredException()
+            : base("Expected AddJsonOptionsForSwaggerReactApp to have been called on the MVC builder before calling AddSwaggerGenForReactApp.")
+        {
+        }
+    }
+}


### PR DESCRIPTION
This also ensures that enumeration value encoding is the same on both React and OpenAPI.