### PR TITLE
Add --wait-for-sysprep option to cluster start

### DIFF
--- a/UET/uet/Commands/Cluster/ClusterOptions.cs
+++ b/UET/uet/Commands/Cluster/ClusterOptions.cs
@@ -13,6 +13,8 @@ namespace UET.Commands.Cluster
         public Option<bool> NoAutoUpgrade = new Option<bool>("--no-auto-upgrade", "If --auto-upgrade was previously passed, this turns off the auto-upgrade system. You can later run 'uet cluster start --auto-upgrade' to turn it back on again.");
 
         public Option<bool> NoStreamLogs = new Option<bool>("--no-stream-logs", "Do not stream logs after the cluster service starts, instead exit.");
+
+        public Option<bool> WaitForSysprep = new Option<bool>("--wait-for-sysprep", "If set, the service will not initialize the node until sysprep has finished. This is detected by checking if 'C:\\Windows\\Panther\\UnattendGC\\setupact.log' contains the line 'OOBE completion WNF notification is already published'. This is necessary if sysprep will change the computer name.");
     }
 
 }

--- a/UET/uet/Commands/Cluster/DefaultRkmClusterControl.cs
+++ b/UET/uet/Commands/Cluster/DefaultRkmClusterControl.cs
@@ -39,7 +39,8 @@ namespace UET.Commands.Cluster
             var node = context.ParseResult.GetValueForOption(options.Node);
             var autoUpgrade = context.ParseResult.GetValueForOption(options.AutoUpgrade);
             var noAutoUpgrade = context.ParseResult.GetValueForOption(options.NoAutoUpgrade);
-            var args = Array.Empty<string>();
+            var waitForSysprep = context.ParseResult.GetValueForOption(options.WaitForSysprep);
+            var args = new List<string>();
             if (controller)
             {
                 args = ["--controller"];
@@ -47,6 +48,10 @@ namespace UET.Commands.Cluster
             if (!string.IsNullOrWhiteSpace(node))
             {
                 args = ["--node", node];
+            }
+            if (waitForSysprep)
+            {
+                args.Add("--wait-for-sysprep");
             }
             await File.WriteAllLinesAsync(Path.Combine(_rkmGlobalRootProvider.RkmGlobalRoot, "service-args"), args);
 


### PR DESCRIPTION
This prevents RKM from initializing prior to sysprep setting the computer name.