### PR TITLE
Allow GRPC_PIPE_PATH_USER environment variable to override gRPC pipe path

### DIFF
--- a/UET/Redpoint.GrpcPipes.Abstractions/Internal/GrpcPipePath.cs
+++ b/UET/Redpoint.GrpcPipes.Abstractions/Internal/GrpcPipePath.cs
@@ -8,6 +8,12 @@
     {
         private static string GetUserPipePath(string pipeName)
         {
+            var grpcUserPipePathOverride = Environment.GetEnvironmentVariable("GRPC_PIPE_PATH_USER");
+            if (!string.IsNullOrWhiteSpace(grpcUserPipePathOverride))
+            {
+                return grpcUserPipePathOverride;
+            }
+
             if (OperatingSystem.IsWindows())
             {
                 if (WindowsIdentity.GetCurrent().IsSystem)


### PR DESCRIPTION
This can be used in environments where the default path would be read-only (such as on Linux with a read-only root filesystem).