### PR TITLE
Remove requirement to specify --host-address argument

### DIFF
--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/Endpoints/UnauthenticatedFileTransfer/RkmProvisionContextUnauthenticatedFileTransferEndpoint.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/Endpoints/UnauthenticatedFileTransfer/RkmProvisionContextUnauthenticatedFileTransferEndpoint.cs
@@ -12,6 +12,12 @@
 
         public async Task<Stream?> GetDownloadStreamAsync(UnauthenticatedFileTransferRequest request, CancellationToken cancellationToken)
         {
+            if (request.HttpContext == null)
+            {
+                // TFTP not supported.
+                return null;
+            }
+
             var node = await request.ConfigurationSource.GetRkmNodeByRegisteredIpAddressAsync(
                 request.RemoteAddress.ToString(),
                 cancellationToken);
@@ -23,7 +29,7 @@
                 stream,
                 new WindowsRkmProvisionContext
                 {
-                    ApiAddress = request.HostAddress.ToString(),
+                    ApiAddress = request.HttpContext.Connection.LocalIpAddress.ToString(),
                     BootedFromStepIndex = bootedFromStepIndex,
                     IsInRecovery = false,
                 },

--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/Endpoints/UnauthenticatedFileTransfer/UnauthenticatedFileTransferRequest.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/Endpoints/UnauthenticatedFileTransfer/UnauthenticatedFileTransferRequest.cs
@@ -20,8 +20,6 @@
 
         public required DirectoryInfo StorageFilesDirectory { get; init; }
 
-        public required IPAddress HostAddress { get; init; }
-
         public required int HostHttpPort { get; init; }
 
         public required int HostHttpsPort { get; init; }

--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/Handlers/DefaultPxeBootHttpRequestHandler.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/Handlers/DefaultPxeBootHttpRequestHandler.cs
@@ -53,7 +53,6 @@
                             ConfigurationSource = serverContext.ConfigurationSource,
                             StaticFilesDirectory = serverContext.StaticFilesDirectory,
                             StorageFilesDirectory = serverContext.StorageFilesDirectory,
-                            HostAddress = serverContext.HostAddress,
                             HostHttpPort = serverContext.HostHttpPort,
                             HostHttpsPort = serverContext.HostHttpsPort,
                             JsonSerializerContext = serverContext.JsonSerializerContext,
@@ -121,7 +120,7 @@
                 serverContext.ConfigurationSource,
                 serverContext.JsonSerializerContext,
                 serverContext.StorageFilesDirectory,
-                serverContext.HostAddress.ToString(),
+                httpContext.Connection.LocalIpAddress.ToString(),
                 serverContext.HostHttpPort,
                 serverContext.HostHttpsPort);
 
@@ -173,7 +172,7 @@
 
         public async Task HandleRequestAsync(PxeBootServerContext serverContext, HttpContext httpContext)
         {
-            _logger.LogInformation($"HTTP: Incoming request from {httpContext.Connection.RemoteIpAddress} for '{httpContext.Request.Path}'.");
+            _logger.LogInformation($"HTTP: Incoming request on {httpContext.Connection.LocalIpAddress} from {httpContext.Connection.RemoteIpAddress} for '{httpContext.Request.Path}'.");
 
             // @note: There's some weird bug in Hyper-V where the source IP address of connections from the VM to the host
             // can appear as the host's IP address. This is only dangerous when fetching the /autoexec.ipxe file during

--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/Handlers/DefaultPxeBootTftpRequestHandler.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/Handlers/DefaultPxeBootTftpRequestHandler.cs
@@ -74,7 +74,6 @@
                                 ConfigurationSource = serverContext.ConfigurationSource,
                                 StaticFilesDirectory = serverContext.StaticFilesDirectory,
                                 StorageFilesDirectory = serverContext.StorageFilesDirectory,
-                                HostAddress = serverContext.HostAddress,
                                 HostHttpPort = serverContext.HostHttpPort,
                                 HostHttpsPort = serverContext.HostHttpsPort,
                                 JsonSerializerContext = serverContext.JsonSerializerContext,

--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/Handlers/PxeBootServerContext.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/Handlers/PxeBootServerContext.cs
@@ -12,8 +12,6 @@
 
         public required DirectoryInfo StorageFilesDirectory { get; init; }
 
-        public required IPAddress HostAddress { get; init; }
-
         public required int HostHttpPort { get; init; }
 
         public required int HostHttpsPort { get; init; }

--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/PxeBootHostedService.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/PxeBootHostedService.cs
@@ -98,7 +98,6 @@ namespace Redpoint.KubernetesManager.PxeBoot.Server
                 },
                 StaticFilesDirectory = _commandInvocationContext.ParseResult.GetValueForOption(_options.StaticFiles)!,
                 StorageFilesDirectory = _commandInvocationContext.ParseResult.GetValueForOption(_options.StorageFiles)!,
-                HostAddress = _commandInvocationContext.ParseResult.GetValueForOption(_options.HostAddress) ?? IPAddress.Parse("192.168.0.1"),
                 HostHttpPort = _httpPort,
                 HostHttpsPort = _httpsPort,
                 JsonSerializerContext = KubernetesRkmJsonSerializerContext.CreateStringEnumWithAdditionalConverters(

--- a/UET/Redpoint.KubernetesManager.PxeBoot/Server/PxeBootServerOptions.cs
+++ b/UET/Redpoint.KubernetesManager.PxeBoot/Server/PxeBootServerOptions.cs
@@ -14,10 +14,6 @@
             () => PxeBootServerSource.Test,
             "The configuration source.");
 
-        public Option<IPAddress> HostAddress = new Option<IPAddress>(
-            "--host-address",
-            "The address that the PXE boot server is listening on; used to notify machines of the API address.");
-
         public Option<DirectoryInfo> StaticFiles = new Option<DirectoryInfo>(
             "--static-files",
             () => new DirectoryInfo("/static"),


### PR DESCRIPTION
This argument is awkward when running in Kubernetes, so ditch it and use `${next-server}` for TFTP and `LocalIpAddress` for HTTP requests.