### PR TITLE
Redirect kube-proxy output on Windows to make diagnosing issues easier

### DIFF
--- a/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows.yaml
+++ b/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows.yaml
@@ -91,7 +91,8 @@ spec:
             - .\pwsh\pwsh.exe
             - -ExecutionPolicy
             - Bypass
-            - .\scripts\kube_proxy.ps1
+            - -Command
+            - .\scripts\kube_proxy.ps1 2>&1 | Tee-Object -FilePath C:\RKM\kube-proxy.log
           volumeMounts:
             - mountPath: /scripts
               name: scripts


### PR DESCRIPTION
kube-proxy is used to downloads logs for containers, so if kube-proxy doesn't start properly, we can't look at the logs for the kube-proxy process itself. This redirects the kube-proxy script output to "C:\RKM\kube-proxy.log" on Windows to make it easier to diagnose why kube-proxy isn't running.