### PR TITLE
Remove liveness probe from kube-proxy-windows

### DIFF
--- a/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows.yaml
+++ b/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows.yaml
@@ -100,12 +100,6 @@ spec:
           env:
             - name: UET_KUBERNETES_VERSION
               value: {{ $kubernetesVersion | quote }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 10256
-            initialDelaySeconds: 90
-            periodSeconds: 5
       volumes:
         - name: scripts
           configMap:


### PR DESCRIPTION
This liveness probe doesn't seem to be very reliable, so remove it for now.