### PR TITLE
Fix target not being passed to GetEnvironmentVariable

### DIFF
--- a/UET/Redpoint.PathResolution/DefaultPathResolver.cs
+++ b/UET/Redpoint.PathResolution/DefaultPathResolver.cs
@@ -9,8 +9,8 @@
                 : [EnvironmentVariableTarget.Process];
             foreach (var target in targets)
             {
-                var paths = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty).Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
-                var pathExts = OperatingSystem.IsWindows() ? (Environment.GetEnvironmentVariable("PATHEXT") ?? string.Empty).Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) : [];
+                var paths = (Environment.GetEnvironmentVariable("PATH", target) ?? string.Empty).Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+                var pathExts = OperatingSystem.IsWindows() ? (Environment.GetEnvironmentVariable("PATHEXT", target) ?? string.Empty).Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) : [];
 
                 foreach (var path in paths)
                 {


### PR DESCRIPTION
Not sure how this bug lasted this long, but the environment targets weren't being passed into GetEnvironmentVariable so the user and machine PATH variables were never used as search paths on Windows.