### PR TITLE
Deploy kube-proxy Windows monitor to cluster

### DIFF
--- a/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor-role-binding.yaml
+++ b/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor-role-binding.yaml
@@ -1,0 +1,18 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-proxy-windows-monitor
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    rkm.redpoint.games/component: kube-proxy-windows-monitor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-proxy-windows-monitor
+subjects:
+- kind: ServiceAccount
+  name: kube-proxy-windows-monitor

--- a/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor-role.yaml
+++ b/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor-role.yaml
@@ -1,0 +1,21 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-proxy-windows-monitor
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    rkm.redpoint.games/component: kube-proxy-windows-monitor
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "delete"

--- a/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor-service-account.yaml
+++ b/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor-service-account.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-proxy-windows-monitor
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    rkm.redpoint.games/component: kube-proxy-windows-monitor

--- a/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor.yaml
+++ b/UET/Lib/Helm/rkm/templates/kube-proxy-windows/kube-proxy-windows-monitor.yaml
@@ -1,0 +1,46 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: kube-proxy-windows-monitor
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    rkm.redpoint.games/component: kube-proxy-windows-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      rkm.redpoint.games/component: kube-proxy-windows-monitor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        rkm.redpoint.games/component: kube-proxy-windows-monitor
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      serviceAccountName: kube-proxy-windows-monitor
+      terminationGracePeriodSeconds: 0
+      priorityClassName: system-node-critical
+      containers:
+        - name: kube-proxy-windows-monitor
+          image: {{ printf "ghcr.io/redpointgames/uet/uet:%s" .Values.versions.rkm | quote }}
+          command:
+            - uet
+            - cluster
+            - terminate-stuck-kube-proxy
+            - --in-cluster


### PR DESCRIPTION
This deployment in RKM by default will delete any kube-proxy Windows pods that are stuck.