### PR TITLE
Remove OpenTelemetry tracing

### DIFF
--- a/UET/Directory.Packages.props
+++ b/UET/Directory.Packages.props
@@ -1,125 +1,120 @@
 <Project>
-	<Import Project="$(MSBuildThisFileDirectory)Lib/Framework.Build.props" Condition="'$(RedpointIsFrameworkImported)' != 'true'" />
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<MicrosoftPackageVersion>10.0.9</MicrosoftPackageVersion>
-		<SentryPackageVersion>6.6.0</SentryPackageVersion>
-		<XunitPackageVersion>3.2.2</XunitPackageVersion>
-		<MicrosoftAnalyzersVersion>5.6.0</MicrosoftAnalyzersVersion>
-		<MicrosoftTestingAnalyzersVersion>1.1.4</MicrosoftTestingAnalyzersVersion>
-	</PropertyGroup>
-	<ItemGroup>
-		<!-- System libraries whose version is tied with framework version -->
-		<PackageVersion Include="AWSSDK.S3" Version="4.0.100.2" />
-		<PackageVersion Include="Cronos" Version="0.13.0" />
-		<PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.11" />
-		<PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.11" />
-		<PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Dism" Version="6.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.TSS" Version="2.1.1" />
-		<PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
-		<PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.3-beta.1" />
-		<PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-		<PackageVersion Include="SourceGear.sqlite3" Version="3.53.3" />
-		<PackageVersion Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.2" />
-		<PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
-		<PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
-		<PackageVersion Include="System.Diagnostics.EventLog" Version="$(MicrosoftPackageVersion)" />
-		<!-- Redpoint native libraries -->
-		<PackageVersion Include="Redpoint.AutoDiscovery.Win32" Version="2024.1358.192" />
-		<PackageVersion Include="Redpoint.AutoDiscovery.Win64" Version="2024.1358.192" />
-		<PackageVersion Include="Redpoint.Logging.Mac.Native" Version="2024.1358.192" />
-		<PackageVersion Include="Redpoint.ThirdParty.LibGit2Sharp" Version="2023.177.63629" />
-		<!-- LINQ async support for older frameworks -->
-		<PackageVersion Include="System.Linq.Async" Version="7.0.1" />
-		<!-- gRPC -->
-		<PackageVersion Include="Google.Protobuf" Version="3.35.1" />
-		<PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
-		<PackageVersion Include="Grpc.Tools" Version="2.81.1" />
-		<!-- Google Cloud for Cloud Framework -->
-		<PackageVersion Include="Google.Cloud.BigQuery.V2" Version="3.12.0" />
-		<PackageVersion Include="Google.Cloud.Datastore.V1" Version="5.2.0" />
-		<PackageVersion Include="Google.Cloud.Monitoring.V3" Version="3.16.0" />
-		<PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.36.0" />
-		<PackageVersion Include="Google.Cloud.SecretManager.V1" Version="2.7.0" />
-		<!-- Dependencies for Cloud Framework -->
-		<PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.11" />
-		<PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Docker.DotNet" Version="3.125.15" />
-		<PackageVersion Include="NodaTime" Version="3.3.2" />
-		<PackageVersion Include="S2Geometry" Version="1.0.3" />
-		<PackageVersion Include="Sentry.AspNetCore" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="Sentry.Profiling" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="SharpZipLib" Version="1.4.2" />
-		<PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-		<!-- Testing frameworks and libraries -->
-		<PackageVersion Include="xunit.v3" Version="$(XunitPackageVersion)" />
-		<PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitPackageVersion)" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
-		<PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-		<PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.7.0" />
-		<!-- Default versions for CsWin32 -->
-		<PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
-		<PackageVersion Include="Microsoft.Windows.SDK.Win32Docs" Version="0.1.42-alpha" />
-		<PackageVersion Include="Microsoft.Windows.SDK.Win32Metadata" Version="70.0.11-preview" />
-		<PackageVersion Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.13.25-experimental" />
-		<!-- Other unrelated dependencies of third-party libraries -->
-		<PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageVersion Include="docfx.console" Version="2.59.3" />
-		<PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-		<PackageVersion Include="ZstdNet" Version="1.5.7" />
-		<!-- Assorted dependencies that don't fit anywhere else -->
-		<PackageVersion Include="Octokit" Version="14.0.0" />
-		<PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
-		<PackageVersion Include="System.IO.Hashing" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Crayon" Version="2.0.69" />
-		<PackageVersion Include="Sentry" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="Sentry.OpenTelemetry" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="Sentry.Extensions.Logging" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="System.ServiceProcess.ServiceController" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="KeyedSemaphores" Version="6.1.0" />
-		<PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
-		<PackageVersion Include="YamlDotNet" Version="18.1.0" />
-		<PackageVersion Include="KubernetesClient.Aot" Version="19.0.2" />
-		<!-- Libraries for Io build monitor -->
-		<PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.2" />
-		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-		<PackageVersion Include="StackExchange.Redis" Version="3.0.11" />
-	</ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)Lib/Framework.Build.props" Condition="'$(RedpointIsFrameworkImported)' != 'true'" />
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MicrosoftPackageVersion>10.0.9</MicrosoftPackageVersion>
+    <SentryPackageVersion>6.6.0</SentryPackageVersion>
+    <XunitPackageVersion>3.2.2</XunitPackageVersion>
+    <MicrosoftAnalyzersVersion>5.6.0</MicrosoftAnalyzersVersion>
+    <MicrosoftTestingAnalyzersVersion>1.1.4</MicrosoftTestingAnalyzersVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- System libraries whose version is tied with framework version -->
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.100.2" />
+    <PackageVersion Include="Cronos" Version="0.13.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Dism" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.TSS" Version="2.1.1" />
+    <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.3-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="SourceGear.sqlite3" Version="3.53.3" />
+    <PackageVersion Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.2" />
+    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="$(MicrosoftPackageVersion)" />
+    <!-- Redpoint native libraries -->
+    <PackageVersion Include="Redpoint.AutoDiscovery.Win32" Version="2024.1358.192" />
+    <PackageVersion Include="Redpoint.AutoDiscovery.Win64" Version="2024.1358.192" />
+    <PackageVersion Include="Redpoint.Logging.Mac.Native" Version="2024.1358.192" />
+    <PackageVersion Include="Redpoint.ThirdParty.LibGit2Sharp" Version="2023.177.63629" />
+    <!-- LINQ async support for older frameworks -->
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
+    <!-- gRPC -->
+    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.81.1" />
+    <!-- Google Cloud for Cloud Framework -->
+    <PackageVersion Include="Google.Cloud.BigQuery.V2" Version="3.12.0" />
+    <PackageVersion Include="Google.Cloud.Datastore.V1" Version="5.2.0" />
+    <PackageVersion Include="Google.Cloud.Monitoring.V3" Version="3.16.0" />
+    <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.36.0" />
+    <PackageVersion Include="Google.Cloud.SecretManager.V1" Version="2.7.0" />
+    <!-- Dependencies for Cloud Framework -->
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <PackageVersion Include="NodaTime" Version="3.3.2" />
+    <PackageVersion Include="S2Geometry" Version="1.0.3" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="Sentry.Profiling" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <!-- Testing frameworks and libraries -->
+    <PackageVersion Include="xunit.v3" Version="$(XunitPackageVersion)" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitPackageVersion)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.7.0" />
+    <!-- Default versions for CsWin32 -->
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
+    <PackageVersion Include="Microsoft.Windows.SDK.Win32Docs" Version="0.1.42-alpha" />
+    <PackageVersion Include="Microsoft.Windows.SDK.Win32Metadata" Version="70.0.11-preview" />
+    <PackageVersion Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.13.25-experimental" />
+    <!-- Other unrelated dependencies of third-party libraries -->
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
+    <PackageVersion Include="docfx.console" Version="2.59.3" />
+    <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
+    <PackageVersion Include="ZstdNet" Version="1.5.7" />
+    <!-- Assorted dependencies that don't fit anywhere else -->
+    <PackageVersion Include="Octokit" Version="14.0.0" />
+    <PackageVersion Include="BitFaster.Caching" Version="2.6.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Crayon" Version="2.0.69" />
+    <PackageVersion Include="Sentry" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="Sentry.OpenTelemetry" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="Sentry.Extensions.Logging" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="KeyedSemaphores" Version="6.1.0" />
+    <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
+    <PackageVersion Include="KubernetesClient.Aot" Version="19.0.2" />
+    <!-- Libraries for Io build monitor -->
+    <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.2" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.11" />
+  </ItemGroup>
 </Project>

--- a/UET/Redpoint.CloudFramework/Redpoint.CloudFramework.csproj
+++ b/UET/Redpoint.CloudFramework/Redpoint.CloudFramework.csproj
@@ -29,17 +29,10 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="NodaTime" />
 		<PackageReference Include="NSec.Cryptography" />
-		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore">
-			<NoWarn>NU5104</NoWarn>
-		</PackageReference>
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener">
 			<NoWarn>NU5104</NoWarn>
 		</PackageReference>
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 		<PackageReference Include="S2Geometry" />
 		<PackageReference Include="Sentry.AspNetCore" />
 		<PackageReference Include="Sentry.OpenTelemetry" />

--- a/UET/Redpoint.CloudFramework/Startup/BaseConfigurator.cs
+++ b/UET/Redpoint.CloudFramework/Startup/BaseConfigurator.cs
@@ -190,59 +190,17 @@ namespace Redpoint.CloudFramework.Startup
             services.AddMetrics();
             try
             {
-                if (!hostEnvironment.IsDevelopment() || Environment.GetEnvironmentVariable("REDPOINT_OTEL_USE_TELEMETRY_IN_DEVELOPMENT") == "1")
-                {
-                    var telemetryBuilder = services.AddOpenTelemetry();
-                    var serviceName = Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME");
-                    if (!string.IsNullOrWhiteSpace(serviceName))
-                    {
-                        var serviceNamespace = Environment.GetEnvironmentVariable("OTEL_SERVICE_NAMESPACE");
-                        var serviceVersion = Environment.GetEnvironmentVariable("SENTRY_RELEASE");
-                        Console.WriteLine($"Setting resource name for telemetry to service_name={serviceName},service_namespace={serviceNamespace},service_version={serviceVersion}");
-                        telemetryBuilder = telemetryBuilder
-                            .ConfigureResource(resource =>
-                            {
-                                resource.AddService(serviceName ?? "service-name-not-set", serviceNamespace, serviceVersion);
-                            });
-                    }
-                    telemetryBuilder = telemetryBuilder
-                        .WithMetrics(builder => builder
-                            .AddMeter("*")
-                            .AddPrometheusHttpListener(options =>
-                            {
-                                var prometheusPrefix = configuration["CloudFramework:Prometheus:HttpPrefix"];
-                                if (!string.IsNullOrWhiteSpace(prometheusPrefix))
-                                {
-                                    options.UriPrefixes = [prometheusPrefix];
-                                }
-                            }))
-                        .WithTracing(tracing =>
+                services.AddOpenTelemetry()
+                    .WithMetrics(builder => builder
+                        .AddMeter("*")
+                        .AddPrometheusHttpListener(options =>
                         {
-                            tracing = tracing
-                                .AddAspNetCoreInstrumentation()
-                                .AddHttpClientInstrumentation();
-
-                            var otlpEndpoint = Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT");
-                            if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+                            var prometheusPrefix = configuration["CloudFramework:Prometheus:HttpPrefix"];
+                            if (!string.IsNullOrWhiteSpace(prometheusPrefix))
                             {
-                                Console.WriteLine($"Enabling tracing with OTLP export endpoint: {otlpEndpoint}");
-                                tracing = tracing.AddOtlpExporter(otlp =>
-                                {
-                                    otlp.Endpoint = new Uri(otlpEndpoint!);
-                                    otlp.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
-                                });
+                                options.UriPrefixes = [prometheusPrefix];
                             }
-
-                            tracing = tracing
-                                .AddSource(OtelManagedTracer._sourceName)
-                                .SetSampler(new TraceIdRatioBasedSampler(_tracingRate));
-
-                            if (!string.IsNullOrWhiteSpace(configuration["Sentry:Dsn"]))
-                            {
-                                tracing = tracing.AddSentry();
-                            }
-                        });
-                }
+                        }));
             }
             catch (Exception ex)
             {

--- a/UET/Redpoint.CloudFramework/Startup/DefaultWebAppConfigurator.cs
+++ b/UET/Redpoint.CloudFramework/Startup/DefaultWebAppConfigurator.cs
@@ -221,10 +221,6 @@ namespace Redpoint.CloudFramework.Startup
 
                             options.ProfilesSampleRate = _tracingRate;
                             options.AddProfilingIntegration();
-
-                            // We use OpenTelemetry for tracing.
-                            options.UseOpenTelemetry();
-                            options.DisableSentryHttpMessageHandler = true;
                         });
                 })
                 .ConfigureServices((context, services) =>

--- a/UET/Redpoint.CloudFramework/Startup/DefaultWebAppConfigurator.cs
+++ b/UET/Redpoint.CloudFramework/Startup/DefaultWebAppConfigurator.cs
@@ -219,7 +219,7 @@ namespace Redpoint.CloudFramework.Startup
 
                             options.Environment = context.HostingEnvironment.EnvironmentName;
 
-                            options.ProfilesSampleRate = _tracingRate;
+                            options.ProfilesSampleRate = 1.0;
                             options.AddProfilingIntegration();
                         });
                 })


### PR DESCRIPTION
We still use OpenTelemetry for metrics collections with Prometheus, but this removes the OpenTelemetry exporter and tracing configuration. OpenTelemetry tracing still isn't stable, we're not using it in production, and I think it's interfering with the Sentry profiling data being sent.