### PR TITLE
Make UntypedKey abstract so all instances are concrete instances of Key<T>

### DIFF
--- a/UET/Redpoint.CloudFramework.Tests/Converters/ConverterTests.cs
+++ b/UET/Redpoint.CloudFramework.Tests/Converters/ConverterTests.cs
@@ -386,7 +386,7 @@
         {
             var converter = GetConverter(FieldType.UnsafeKey);
 
-            var key = new UntypedKey(new Key
+            var key = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -403,7 +403,7 @@
                 converter,
                 value =>
                 {
-                    Assert.Equal(key, new UntypedKey(value.KeyValue));
+                    Assert.Equal(key, new Key<ConverterTestModel>(value.KeyValue));
                 },
                 FieldType.UnsafeKey,
                 "\"#v1|project||key:id=1\"",
@@ -692,7 +692,9 @@
         {
             var converter = GetConverter(FieldType.Key);
 
-            var key = new UntypedKey(new Key
+            _ = ReferenceModelCache.Get<ConverterTestModel>();
+
+            UntypedKey key = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -709,7 +711,7 @@
                 converter,
                 value =>
                 {
-                    Assert.Equal(key, new UntypedKey(value.KeyValue));
+                    Assert.Equal(key, new Key<ConverterTestModel>(value.KeyValue));
                 },
                 FieldType.Key,
                 "\"#v1|project||key:id=1\"",
@@ -752,7 +754,9 @@
         {
             var converter = GetConverter(FieldType.GlobalKey);
 
-            var key = new UntypedKey(new Key
+            _ = ReferenceModelCache.Get<ConverterTestModel>();
+
+            UntypedKey key = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -769,7 +773,7 @@
                 converter,
                 value =>
                 {
-                    Assert.Equal(key, new UntypedKey(value.KeyValue));
+                    Assert.Equal(key, new Key<ConverterTestModel>(value.KeyValue));
                 },
                 FieldType.GlobalKey,
                 "\"#v1|project||key:id=1\"",
@@ -812,7 +816,9 @@
         {
             var converter = GetConverter(FieldType.LocalKey);
 
-            var key = new UntypedKey(new Key
+            _ = ReferenceModelCache.Get<ConverterTestModel>();
+
+            UntypedKey key = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -830,7 +836,7 @@
                 converter,
                 value =>
                 {
-                    Assert.Equal(key, new UntypedKey(value.KeyValue));
+                    Assert.Equal(key, new Key<ConverterTestModel>(value.KeyValue));
                 },
                 FieldType.LocalKey,
                 "\"#v1|project|local|key:id=1\"",
@@ -874,7 +880,9 @@
         {
             var converter = GetConverter(FieldType.KeyArray);
 
-            var key1 = new UntypedKey(new Key
+            _ = ReferenceModelCache.Get<ConverterTestModel>();
+
+            var key1 = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -885,7 +893,7 @@
                     new Key.Types.PathElement("key", 1)
                 }
             });
-            var key2 = new UntypedKey(new Key
+            var key2 = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -896,7 +904,7 @@
                     new Key.Types.PathElement("key", 2)
                 }
             });
-            var key3 = new UntypedKey(new Key
+            var key3 = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -920,9 +928,9 @@
                 value =>
                 {
                     Assert.Equal(3, value.ArrayValue.Values.Count);
-                    Assert.Equal(key1, new UntypedKey(value.ArrayValue.Values[0].KeyValue));
-                    Assert.Equal(key2, new UntypedKey(value.ArrayValue.Values[1].KeyValue));
-                    Assert.Equal(key3, new UntypedKey(value.ArrayValue.Values[2].KeyValue));
+                    Assert.Equal(key1, new Key<ConverterTestModel>(value.ArrayValue.Values[0].KeyValue));
+                    Assert.Equal(key2, new Key<ConverterTestModel>(value.ArrayValue.Values[1].KeyValue));
+                    Assert.Equal(key3, new Key<ConverterTestModel>(value.ArrayValue.Values[2].KeyValue));
                 },
                 FieldType.KeyArray,
                 "[\"#v1|project||key:id=1\",\"#v1|project||key:id=2\",\"#v1|project||key:id=3\"]",
@@ -996,7 +1004,9 @@
         {
             var converter = GetConverter(FieldType.GlobalKeyArray);
 
-            var key1 = new UntypedKey(new Key
+            _ = ReferenceModelCache.Get<ConverterTestModel>();
+
+            var key1 = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -1007,7 +1017,7 @@
                     new Key.Types.PathElement("key", 1)
                 }
             });
-            var key2 = new UntypedKey(new Key
+            var key2 = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -1018,7 +1028,7 @@
                     new Key.Types.PathElement("key", 2)
                 }
             });
-            var key3 = new UntypedKey(new Key
+            var key3 = new Key<ConverterTestModel>(new Key
             {
                 PartitionId = new PartitionId
                 {
@@ -1036,9 +1046,9 @@
                 value =>
                 {
                     Assert.Equal(3, value.ArrayValue.Values.Count);
-                    Assert.Equal(key1, new UntypedKey(value.ArrayValue.Values[0].KeyValue));
-                    Assert.Equal(key2, new UntypedKey(value.ArrayValue.Values[1].KeyValue));
-                    Assert.Equal(key3, new UntypedKey(value.ArrayValue.Values[2].KeyValue));
+                    Assert.Equal(key1, new Key<ConverterTestModel>(value.ArrayValue.Values[0].KeyValue));
+                    Assert.Equal(key2, new Key<ConverterTestModel>(value.ArrayValue.Values[1].KeyValue));
+                    Assert.Equal(key3, new Key<ConverterTestModel>(value.ArrayValue.Values[2].KeyValue));
                 },
                 FieldType.GlobalKeyArray,
                 "[\"#v1|project||key:id=1\",\"#v1|project||key:id=2\",\"#v1|project||key:id=3\"]",
@@ -1054,9 +1064,9 @@
                 value =>
                 {
                     Assert.Equal(3, value.ArrayValue.Values.Count);
-                    Assert.Equal(key1, new UntypedKey(value.ArrayValue.Values[0].KeyValue));
-                    Assert.Equal(key2, new UntypedKey(value.ArrayValue.Values[1].KeyValue));
-                    Assert.Equal(key3, new UntypedKey(value.ArrayValue.Values[2].KeyValue));
+                    Assert.Equal(key1, new Key<ConverterTestModel>(value.ArrayValue.Values[0].KeyValue));
+                    Assert.Equal(key2, new Key<ConverterTestModel>(value.ArrayValue.Values[1].KeyValue));
+                    Assert.Equal(key3, new Key<ConverterTestModel>(value.ArrayValue.Values[2].KeyValue));
                 },
                 FieldType.GlobalKeyArray,
                 "[\"#v1|project||key:id=1\",\"#v1|project||key:id=2\",\"#v1|project||key:id=3\"]",

--- a/UET/Redpoint.CloudFramework/Models/IReferenceModel.cs
+++ b/UET/Redpoint.CloudFramework/Models/IReferenceModel.cs
@@ -23,8 +23,6 @@
         UntypedKey? GetUntypedKey(IModel model);
         [return: NotNullIfNotNull(nameof(key))]
         UntypedKey? ConvertDatastoreKeyToUntypedKey(DatastoreKey? key);
-        [return: NotNullIfNotNull(nameof(key))]
-        object? ConvertDatastoreKeyToDynamicTypedKey(DatastoreKey? key);
         UntypedKey[] ConstructDynamicTypedKeyArray(int length);
         [SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "This is a factory method.")]
         (object list, Action<UntypedKey> addEntry) ConstructDynamicTypedKeyList(int length);

--- a/UET/Redpoint.CloudFramework/Models/ReferenceModelCache.cs
+++ b/UET/Redpoint.CloudFramework/Models/ReferenceModelCache.cs
@@ -13,6 +13,7 @@
     {
         private static Dictionary<Type, IReferenceModel> _referenceCache = [];
         private static Dictionary<Type, IReferenceModel> _referenceByKeyCache = [];
+        private static Dictionary<string, IReferenceModel> _referenceByKind = [];
         private static readonly IValueConverter[] _stringEnumValueConverters =
         [
             new StringEnumValueConverter(),
@@ -51,6 +52,21 @@
             if (!_referenceCache.TryGetValue(type, out var result))
             {
                 throw new InvalidOperationException($"Model type '{type.FullName}' is not registered with reference model cache, which should be impossible since all models implicitly call InitModel in the base constructor.");
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a reference model representing static metadata about a given model, based on the underlying kind.
+        /// </summary>
+        /// <param name="kind">The Datastore kind to lookup metadata for.</param>
+        /// <returns>The reference model.</returns>
+        public static IReferenceModel Get(string kind)
+        {
+            ArgumentNullException.ThrowIfNull(kind);
+            if (!_referenceByKind.TryGetValue(kind, out var result))
+            {
+                throw new InvalidOperationException($"Model kind '{kind}' is not registered with reference model cache, which should be impossible since all models implicitly call InitModel in the base constructor.");
             }
             return result;
         }
@@ -245,6 +261,7 @@
                         getTypedKey);
                     _referenceCache[typeof(T)] = referenceModel;
                     _referenceByKeyCache[typeof(Key<T>)] = referenceModel;
+                    _referenceByKind[referenceModel.Kind] = referenceModel;
                 }
 
                 foreach (var referencedType in modelTypesReferencedFromKeyFields)
@@ -434,17 +451,6 @@
 
             [return: NotNullIfNotNull(nameof(key))]
             public UntypedKey? ConvertDatastoreKeyToUntypedKey(DatastoreKey? key)
-            {
-                if (key == null)
-                {
-                    return null;
-                }
-
-                return new UntypedKey(key);
-            }
-
-            [return: NotNullIfNotNull(nameof(key))]
-            public object? ConvertDatastoreKeyToDynamicTypedKey(DatastoreKey? key)
             {
                 if (key == null)
                 {

--- a/UET/Redpoint.CloudFramework/Models/UntypedKey.cs
+++ b/UET/Redpoint.CloudFramework/Models/UntypedKey.cs
@@ -6,7 +6,7 @@
     using static Google.Cloud.Datastore.V1.Key.Types;
     using DatastoreKey = Google.Cloud.Datastore.V1.Key;
 
-    public class UntypedKey
+    public abstract class UntypedKey
         : IEquatable<UntypedKey?>
     {
         private readonly DatastoreKey _key;

--- a/UET/Redpoint.CloudFramework/Prefix/GlobalPrefix.cs
+++ b/UET/Redpoint.CloudFramework/Prefix/GlobalPrefix.cs
@@ -69,6 +69,11 @@
             _reversePrefixes = registration.ReversePrefixes;
         }
 
+        private static UntypedKey ConvertToUntypedKey(DatastoreKey datastoreKey)
+        {
+            return ReferenceModelCache.Get(datastoreKey.Path.Last().Kind).ConvertDatastoreKeyToUntypedKey(datastoreKey);
+        }
+
         /// <summary>
         /// Parse a public identifier into a Google Datastore key object.
         /// </summary>
@@ -77,7 +82,7 @@
         /// <returns>A key object.</returns>
         public UntypedKey Parse(string datastoreNamespace, string identifier)
         {
-            return new UntypedKey(ParseToDatastoreKey(datastoreNamespace, identifier));
+            return ConvertToUntypedKey(ParseToDatastoreKey(datastoreNamespace, identifier));
         }
 
         /// <summary>
@@ -100,7 +105,7 @@
                 throw new IdentifierWrongTypeException(identifier, kind);
             }
 
-            return new UntypedKey(result);
+            return ConvertToUntypedKey(result);
         }
 
         /// <summary>
@@ -166,7 +171,7 @@
         /// <returns>A key object.</returns>
         public UntypedKey ParseInternal(string datastoreNamespace, string identifier)
         {
-            return new UntypedKey(ParseInternalToDatastoreKey(datastoreNamespace, identifier));
+            return ConvertToUntypedKey(ParseInternalToDatastoreKey(datastoreNamespace, identifier));
         }
 
         /// <summary>
@@ -201,7 +206,18 @@
         {
             ArgumentNullException.ThrowIfNull(key);
 
-            var datastoreKey = key.__InternalDatastoreKey__;
+            return CreateInternal(key.__InternalDatastoreKey__, pathGenerationMode);
+        }
+
+        /// <summary>
+        /// Creates a public or internal identifier from a Datastore key.
+        /// </summary>
+        /// <param name="datastoreKey">The datastore key to create an identifier from.</param>
+        /// <param name="pathGenerationMode"></param>
+        /// <returns>The public or internal identifier.</returns>
+        public string CreateInternal(DatastoreKey datastoreKey, PathGenerationMode pathGenerationMode = PathGenerationMode.Default)
+        {
+            ArgumentNullException.ThrowIfNull(datastoreKey);
 
             var keyComponents = new List<string>
             {

--- a/UET/Redpoint.CloudFramework/Prefix/IGlobalPrefix.cs
+++ b/UET/Redpoint.CloudFramework/Prefix/IGlobalPrefix.cs
@@ -2,11 +2,13 @@
 {
     using Redpoint.CloudFramework.Models;
     using System.Diagnostics.CodeAnalysis;
+    using DatastoreKey = Google.Cloud.Datastore.V1.Key;
 
     public interface IGlobalPrefix
     {
         string Create(UntypedKey key);
         string CreateInternal(UntypedKey key, PathGenerationMode pathGenerationMode = PathGenerationMode.Default);
+        string CreateInternal(DatastoreKey datastoreKey, PathGenerationMode pathGenerationMode = PathGenerationMode.Default);
         UntypedKey Parse(string datastoreNamespace, string identifier);
         UntypedKey ParseInternal(string datastoreNamespace, string identifier);
         UntypedKey ParseLimited(string datastoreNamespace, string identifier, string kind);

--- a/UET/Redpoint.CloudFramework/Repository/Converters/Expression/DefaultExpressionConverter.cs
+++ b/UET/Redpoint.CloudFramework/Repository/Converters/Expression/DefaultExpressionConverter.cs
@@ -481,7 +481,7 @@
                 case Value.ValueTypeOneofCase.TimestampValue:
                     return value.TimestampValue.ToDateTimeOffset().ToString(CultureInfo.InvariantCulture);
                 case Value.ValueTypeOneofCase.KeyValue:
-                    return _globalPrefix.CreateInternal(new UntypedKey(value.KeyValue), PathGenerationMode.NoShortPathComponents);
+                    return _globalPrefix.CreateInternal(value.KeyValue, PathGenerationMode.NoShortPathComponents);
                 case Value.ValueTypeOneofCase.StringValue:
                     return $"\"{value.StringValue.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
                 case Value.ValueTypeOneofCase.BlobValue:

--- a/UET/Redpoint.CloudFramework/Repository/Converters/Value/EmbeddedEntityValueConverter.cs
+++ b/UET/Redpoint.CloudFramework/Repository/Converters/Value/EmbeddedEntityValueConverter.cs
@@ -276,7 +276,7 @@
                             new JsonObject
                             {
                                 { "ns", value.KeyValue.PartitionId.NamespaceId },
-                                { "value", _globalPrefix.CreateInternal(new UntypedKey(value.KeyValue), PathGenerationMode.NoShortPathComponents) }
+                                { "value", _globalPrefix.CreateInternal(value.KeyValue, PathGenerationMode.NoShortPathComponents) }
                             }
                         }
                     };

--- a/UET/Redpoint.CloudFramework/Repository/Converters/Value/PolicyBasedUntypedKeyArrayValueConverter.cs
+++ b/UET/Redpoint.CloudFramework/Repository/Converters/Value/PolicyBasedUntypedKeyArrayValueConverter.cs
@@ -138,11 +138,11 @@
             }
             else if (propertyClrType == typeof(UntypedKey))
             {
-                return new UntypedKey(datastoreKey);
+                return ReferenceModelCache.Get(datastoreKey.Path.Last().Kind).ConvertDatastoreKeyToUntypedKey(datastoreKey);
             }
             else
             {
-                return ReferenceModelCache.GetFromKeyProperty(propertyClrType).ConvertDatastoreKeyToDynamicTypedKey(datastoreKey);
+                return ReferenceModelCache.GetFromKeyProperty(propertyClrType).ConvertDatastoreKeyToUntypedKey(datastoreKey);
             }
         }
 
@@ -152,14 +152,10 @@
             {
                 return null;
             }
-            else if (propertyClrType == typeof(UntypedKey))
-            {
-                return untypedKey;
-            }
             else
             {
-                // The ParseLimited calls don't construct the concrete Key<T> type, so we need to change the wrapping type here.
-                return ReferenceModelCache.GetFromKeyProperty(propertyClrType).ConvertDatastoreKeyToDynamicTypedKey(untypedKey.__InternalDatastoreKey__);
+                // UntypedKey is now abstract, so all instantiations are the correct concrete Key<T> type.
+                return untypedKey;
             }
         }
 

--- a/UET/Redpoint.CloudFramework/Repository/Converters/Value/PolicyBasedUntypedKeyValueConverter.cs
+++ b/UET/Redpoint.CloudFramework/Repository/Converters/Value/PolicyBasedUntypedKeyValueConverter.cs
@@ -65,11 +65,11 @@
             }
             else if (propertyClrType == typeof(UntypedKey))
             {
-                return new UntypedKey(datastoreKey);
+                return ReferenceModelCache.Get(datastoreKey.Path.Last().Kind).ConvertDatastoreKeyToUntypedKey(datastoreKey);
             }
             else
             {
-                return ReferenceModelCache.GetFromKeyProperty(propertyClrType).ConvertDatastoreKeyToDynamicTypedKey(datastoreKey);
+                return ReferenceModelCache.GetFromKeyProperty(propertyClrType).ConvertDatastoreKeyToUntypedKey(datastoreKey);
             }
         }
 
@@ -79,14 +79,10 @@
             {
                 return null;
             }
-            else if (propertyClrType == typeof(UntypedKey))
-            {
-                return untypedKey;
-            }
             else
             {
-                // The ParseLimited calls don't construct the concrete Key<T> type, so we need to change the wrapping type here.
-                return ReferenceModelCache.GetFromKeyProperty(propertyClrType).ConvertDatastoreKeyToDynamicTypedKey(untypedKey.__InternalDatastoreKey__);
+                // UntypedKey is now abstract, so all instantiations are the correct concrete Key<T> type.
+                return untypedKey;
             }
         }
 


### PR DESCRIPTION
This ensures that when a user obtains an `UntypedKey`, it can be cast to a more specific `Key<T>` via the `as` operator.