### PR TITLE
Add support for runtime patching via DOTNET_STARTUP_HOOKS

### DIFF
--- a/UET/Directory.Packages.props
+++ b/UET/Directory.Packages.props
@@ -1,120 +1,121 @@
 <Project>
-	<Import Project="$(MSBuildThisFileDirectory)Lib/Framework.Build.props" Condition="'$(RedpointIsFrameworkImported)' != 'true'" />
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<MicrosoftPackageVersion>10.0.12</MicrosoftPackageVersion>
-		<SentryPackageVersion>6.8.0</SentryPackageVersion>
-		<XunitPackageVersion>3.2.2</XunitPackageVersion>
-        <!-- If this changes, it will change the minimum version of Visual Studio the analyzers will work with. -->
-		<MicrosoftAnalyzersVersion>5.3.0</MicrosoftAnalyzersVersion>
-		<MicrosoftTestingAnalyzersVersion>1.1.4</MicrosoftTestingAnalyzersVersion>
-	</PropertyGroup>
-	<ItemGroup>
-		<!-- System libraries whose version is tied with framework version -->
-		<PackageVersion Include="AWSSDK.S3" Version="4.0.103" />
-		<PackageVersion Include="Cronos" Version="0.13.0" />
-		<PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.13" />
-		<PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.12" />
-		<PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Dism" Version="6.0.0" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.TSS" Version="2.1.1" />
-		<PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
-		<PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.3-beta.1" />
-		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-		<PackageVersion Include="SourceGear.sqlite3" Version="3.53.3" />
-		<PackageVersion Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.2" />
-		<PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
-		<PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
-		<PackageVersion Include="System.Diagnostics.EventLog" Version="$(MicrosoftPackageVersion)" />
-		<!-- Redpoint native libraries -->
-		<PackageVersion Include="Redpoint.AutoDiscovery.Win32" Version="2024.1358.192" />
-		<PackageVersion Include="Redpoint.AutoDiscovery.Win64" Version="2024.1358.192" />
-		<PackageVersion Include="Redpoint.Logging.Mac.Native" Version="2024.1358.192" />
-		<PackageVersion Include="Redpoint.ThirdParty.LibGit2Sharp" Version="2023.177.63629" />
-		<!-- LINQ async support for older frameworks -->
-		<PackageVersion Include="System.Linq.Async" Version="7.0.1" />
-		<!-- gRPC -->
-		<PackageVersion Include="Google.Protobuf" Version="3.36.1" />
-		<PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
-		<PackageVersion Include="Grpc.Tools" Version="2.83.0" />
-		<!-- Google Cloud for Cloud Framework -->
-		<PackageVersion Include="Google.Cloud.Datastore.V1" Version="5.2.0" />
-		<PackageVersion Include="Google.Cloud.Monitoring.V3" Version="3.16.0" />
-		<PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.37.0" />
-		<PackageVersion Include="Google.Cloud.SecretManager.V1" Version="2.8.0" />
-		<!-- Dependencies for Cloud Framework -->
-		<PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.13" />
-		<PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftAnalyzersVersion)" />
-		<PackageVersion Include="Docker.DotNet" Version="3.125.15" />
-		<PackageVersion Include="NodaTime" Version="3.3.3" />
-		<PackageVersion Include="S2Geometry" Version="1.0.3" />
-		<PackageVersion Include="Sentry.AspNetCore" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="Sentry.Profiling" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="SharpZipLib" Version="1.4.2" />
-		<PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
-		<!-- Testing frameworks and libraries -->
-		<PackageVersion Include="xunit.v3" Version="$(XunitPackageVersion)" />
-		<PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitPackageVersion)" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-		<PackageVersion Include="coverlet.collector" Version="10.0.1" />
-		<PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-		<PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.8.1" />
-		<!-- Default versions for CsWin32 -->
-		<PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
-		<PackageVersion Include="Microsoft.Windows.SDK.Win32Docs" Version="0.1.42-alpha" />
-		<PackageVersion Include="Microsoft.Windows.SDK.Win32Metadata" Version="70.0.11-preview" />
-		<PackageVersion Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.13.25-experimental" />
-		<!-- Other unrelated dependencies of third-party libraries -->
-		<PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
-		<PackageVersion Include="docfx.console" Version="2.59.3" />
-		<PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
-		<PackageVersion Include="ZstdNet" Version="1.5.7" />
-		<!-- Assorted dependencies that don't fit anywhere else -->
-		<PackageVersion Include="Octokit" Version="14.0.0" />
-		<PackageVersion Include="BitFaster.Caching" Version="2.6.1" />
-		<PackageVersion Include="System.IO.Hashing" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Crayon" Version="2.0.69" />
-		<PackageVersion Include="Sentry" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="Sentry.OpenTelemetry" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="Sentry.Extensions.Logging" Version="$(SentryPackageVersion)" />
-		<PackageVersion Include="System.ServiceProcess.ServiceController" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="KeyedSemaphores" Version="6.1.0" />
-		<PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
-		<PackageVersion Include="YamlDotNet" Version="18.1.0" />
-		<PackageVersion Include="KubernetesClient.Aot" Version="19.0.2" />
-		<!-- Libraries for Io build monitor -->
-		<PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftPackageVersion)" />
-		<PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
-		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.3" />
-		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-		<PackageVersion Include="StackExchange.Redis" Version="3.0.17" />
-	</ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)Lib/Framework.Build.props" Condition="'$(RedpointIsFrameworkImported)' != 'true'" />
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <MicrosoftPackageVersion>10.0.12</MicrosoftPackageVersion>
+    <SentryPackageVersion>6.8.0</SentryPackageVersion>
+    <XunitPackageVersion>3.2.2</XunitPackageVersion>
+    <!-- If this changes, it will change the minimum version of Visual Studio the analyzers will work with. -->
+    <MicrosoftAnalyzersVersion>5.3.0</MicrosoftAnalyzersVersion>
+    <MicrosoftTestingAnalyzersVersion>1.1.4</MicrosoftTestingAnalyzersVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- System libraries whose version is tied with framework version -->
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.103" />
+    <PackageVersion Include="Cronos" Version="0.13.0" />
+    <PackageVersion Include="Lib.Harmony" Version="2.4.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.3.12" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Dism" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.TSS" Version="2.1.1" />
+    <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageVersion Include="NSec.Cryptography" Version="26.4.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.15.3-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="SourceGear.sqlite3" Version="3.53.3" />
+    <PackageVersion Include="SQLitePCLRaw.provider.dynamic_cdecl" Version="3.0.2" />
+    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="$(MicrosoftPackageVersion)" />
+    <!-- Redpoint native libraries -->
+    <PackageVersion Include="Redpoint.AutoDiscovery.Win32" Version="2024.1358.192" />
+    <PackageVersion Include="Redpoint.AutoDiscovery.Win64" Version="2024.1358.192" />
+    <PackageVersion Include="Redpoint.Logging.Mac.Native" Version="2024.1358.192" />
+    <PackageVersion Include="Redpoint.ThirdParty.LibGit2Sharp" Version="2023.177.63629" />
+    <!-- LINQ async support for older frameworks -->
+    <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
+    <!-- gRPC -->
+    <PackageVersion Include="Google.Protobuf" Version="3.36.1" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
+    <!-- Google Cloud for Cloud Framework -->
+    <PackageVersion Include="Google.Cloud.Datastore.V1" Version="5.2.0" />
+    <PackageVersion Include="Google.Cloud.Monitoring.V3" Version="3.16.0" />
+    <PackageVersion Include="Google.Cloud.PubSub.V1" Version="3.37.0" />
+    <PackageVersion Include="Google.Cloud.SecretManager.V1" Version="2.8.0" />
+    <!-- Dependencies for Cloud Framework -->
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.13" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="$(MicrosoftTestingAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftAnalyzersVersion)" />
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+    <PackageVersion Include="NodaTime" Version="3.3.3" />
+    <PackageVersion Include="S2Geometry" Version="1.0.3" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="Sentry.Profiling" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <!-- Testing frameworks and libraries -->
+    <PackageVersion Include="xunit.v3" Version="$(XunitPackageVersion)" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XunitPackageVersion)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.8.1" />
+    <!-- Default versions for CsWin32 -->
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.298" />
+    <PackageVersion Include="Microsoft.Windows.SDK.Win32Docs" Version="0.1.42-alpha" />
+    <PackageVersion Include="Microsoft.Windows.SDK.Win32Metadata" Version="70.0.11-preview" />
+    <PackageVersion Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.13.25-experimental" />
+    <!-- Other unrelated dependencies of third-party libraries -->
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
+    <PackageVersion Include="docfx.console" Version="2.59.3" />
+    <PackageVersion Include="K4os.Compression.LZ4" Version="1.3.8" />
+    <PackageVersion Include="ZstdNet" Version="1.5.7" />
+    <!-- Assorted dependencies that don't fit anywhere else -->
+    <PackageVersion Include="Octokit" Version="14.0.0" />
+    <PackageVersion Include="BitFaster.Caching" Version="2.6.1" />
+    <PackageVersion Include="System.IO.Hashing" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Crayon" Version="2.0.69" />
+    <PackageVersion Include="Sentry" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="Sentry.OpenTelemetry" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="Sentry.Extensions.Logging" Version="$(SentryPackageVersion)" />
+    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="KeyedSemaphores" Version="6.1.0" />
+    <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
+    <PackageVersion Include="KubernetesClient.Aot" Version="19.0.2" />
+    <!-- Libraries for Io build monitor -->
+    <PackageVersion Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftPackageVersion)" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.3" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.17" />
+  </ItemGroup>
 </Project>

--- a/UET/Redpoint.Hashing/Hash.cs
+++ b/UET/Redpoint.Hashing/Hash.cs
@@ -120,13 +120,11 @@
         /// <param name="path">The full path to the file to compute the hash of.</param>
         /// <param name="cancellationToken">The cancellation token used to cancel the asynchronous operation.</param>
         /// <returns>The xxHash64 hash value and the byte length of the original file.</returns>
-        public static async Task<XxHash64WithLength> XxHash64OfFileAsync(string path, CancellationToken cancellationToken)
+        public static async Task<XxHash64WithLength> XxHash64OfFileAsync(string path, CancellationToken cancellationToken = default)
         {
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                var hasher = new XxHash64();
-                await hasher.AppendAsync(stream, cancellationToken).ConfigureAwait(false);
-                return new XxHash64WithLength(BitConverter.ToInt64(hasher.GetCurrentHash()), stream.Length);
+                return await XxHash64Async(stream, cancellationToken);
             }
         }
 
@@ -141,6 +139,19 @@
             ArgumentNullException.ThrowIfNull(encoding);
             var bytes = Encoding.UTF8.GetBytes(value);
             return new XxHash64WithLength(BitConverter.ToInt64(System.IO.Hashing.XxHash64.Hash(encoding.GetBytes(value))), bytes.Length);
+        }
+
+        /// <summary>
+        /// Compute the xxHash64 of the specified stream and return both the hash and byte length of the stream.
+        /// </summary>
+        /// <param name="stream">The stream to hash.</param>
+        /// <returns>The xxHash64 hash value and the byte length of the original file.</returns>
+        public static async Task<XxHash64WithLength> XxHash64Async(Stream stream, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            var hasher = new XxHash64();
+            await hasher.AppendAsync(stream, cancellationToken).ConfigureAwait(false);
+            return new XxHash64WithLength(BitConverter.ToInt64(hasher.GetCurrentHash()), stream.Length);
         }
     }
 }

--- a/UET/Redpoint.Uet.Automation.Tests/AutomationRunnerTests.cs
+++ b/UET/Redpoint.Uet.Automation.Tests/AutomationRunnerTests.cs
@@ -50,7 +50,7 @@ namespace Redpoint.Uet.Automation.Tests
             });
             services.AddProcessExecution();
             services.AddUETAutomation();
-            services.AddUETUAT();
+            services.AddUetUat();
             services.AddReservation();
 
             var sp = services.BuildServiceProvider();

--- a/UET/Redpoint.Uet.Automation.Tests/LocalWorkerPoolTests.cs
+++ b/UET/Redpoint.Uet.Automation.Tests/LocalWorkerPoolTests.cs
@@ -41,7 +41,7 @@ namespace Redpoint.Uet.Automation.Tests
             });
             services.AddProcessExecution();
             services.AddUETAutomation();
-            services.AddUETUAT();
+            services.AddUetUat();
 
             var sp = services.BuildServiceProvider();
 
@@ -446,7 +446,7 @@ namespace Redpoint.Uet.Automation.Tests
             services.AddPathResolution();
             services.AddProcessExecution();
             services.AddUETAutomation();
-            services.AddUETUAT();
+            services.AddUetUat();
             services.AddReservation();
             return services;
         }

--- a/UET/Redpoint.Uet.Automation/Worker/Local/LocalGauntletWorker.cs
+++ b/UET/Redpoint.Uet.Automation/Worker/Local/LocalGauntletWorker.cs
@@ -16,7 +16,7 @@
     {
         private readonly ILogger<LocalGauntletWorker> _logger;
         private readonly IProcessExecutor _processExecutor;
-        private readonly IUATExecutor _uatExecutor;
+        private readonly IUatExecutor _uatExecutor;
         private readonly ILoopbackPortReservation _portReservation;
 
         private readonly OnWorkerStarted _onWorkerStarted;
@@ -28,7 +28,7 @@
         public LocalGauntletWorker(
             ILogger<LocalGauntletWorker> logger,
             IProcessExecutor processExecutor,
-            IUATExecutor uatExecutor,
+            IUatExecutor uatExecutor,
             string id,
             string displayName,
             ILoopbackPortReservation portReservation,

--- a/UET/Redpoint.Uet.Automation/Worker/Local/LocalWorkerPool.cs
+++ b/UET/Redpoint.Uet.Automation/Worker/Local/LocalWorkerPool.cs
@@ -174,7 +174,7 @@
                                     newWorker = new LocalGauntletWorker(
                                         _serviceProvider.GetRequiredService<ILogger<LocalGauntletWorker>>(),
                                         _serviceProvider.GetRequiredService<IProcessExecutor>(),
-                                        _serviceProvider.GetRequiredService<IUATExecutor>(),
+                                        _serviceProvider.GetRequiredService<IUatExecutor>(),
                                         newId,
                                         displayName,
                                         portReservation,

--- a/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
+++ b/UET/Redpoint.Uet.BuildPipeline.Tests/BuildGraphGeneratorTests.cs
@@ -21,7 +21,7 @@ namespace Redpoint.Uet.BuildPipeline.Tests
             services.AddProcessExecution();
             services.AddGrpcPipes<TcpGrpcPipeFactory>();
             services.AddUetCore();
-            services.AddUETUAT();
+            services.AddUetUat();
             services.AddUETBuildPipeline();
             services.AddMSBuildPathResolution();
             return services.BuildServiceProvider();

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/DefaultBuildGraphExecutor.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/DefaultBuildGraphExecutor.cs
@@ -21,7 +21,7 @@
     internal class DefaultBuildGraphExecutor : IBuildGraphExecutor
     {
         private readonly ILogger<DefaultBuildGraphExecutor> _logger;
-        private readonly IUATExecutor _uatExecutor;
+        private readonly IUatExecutor _uatExecutor;
         private readonly IBuildGraphArgumentGenerator _buildGraphArgumentGenerator;
         private readonly IBuildGraphPatcher _buildGraphPatcher;
         private readonly IWorkspaceProvider _dynamicWorkspaceProvider;
@@ -32,7 +32,7 @@
 
         public DefaultBuildGraphExecutor(
             ILogger<DefaultBuildGraphExecutor> logger,
-            IUATExecutor uatExecutor,
+            IUatExecutor uatExecutor,
             IBuildGraphArgumentGenerator buildGraphArgumentGenerator,
             IBuildGraphPatcher buildGraphPatcher,
             IWorkspaceProvider dynamicWorkspaceProvider,

--- a/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/DefaultBuildGraphPatcher.cs
+++ b/UET/Redpoint.Uet.BuildPipeline/BuildGraph/Patching/DefaultBuildGraphPatcher.cs
@@ -23,7 +23,7 @@
         private readonly IPathResolver _pathResolver;
         private readonly IProcessExecutor _processExecutor;
         private readonly IWorkspaceProvider _dynamicWorkspaceProvider;
-        private readonly IUATExecutor _uatExecutor;
+        private readonly IUatExecutor _uatExecutor;
         private readonly IDotnetLocator _dotnetLocator;
         private readonly BuildGraphPatchSet[] _patches;
         private readonly string _patchHash;
@@ -36,7 +36,7 @@
             IPathResolver pathResolver,
             IProcessExecutor processExecutor,
             IWorkspaceProvider dynamicWorkspaceProvider,
-            IUATExecutor uatExecutor,
+            IUatExecutor uatExecutor,
             IDotnetLocator dotnetLocator)
         {
             _logger = logger;

--- a/UET/Redpoint.Uet.Patching.Runtime/ConsoleUetPatchLogging.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/ConsoleUetPatchLogging.cs
@@ -1,0 +1,22 @@
+﻿namespace Redpoint.Uet.Patching.Runtime
+{
+    using System;
+
+    internal class ConsoleUetPatchLogging : IUetPatchLogging
+    {
+        public void LogInfo(string message)
+        {
+            Console.WriteLine($"Redpoint.Uet.Patching.Runtime [info] {message}");
+        }
+
+        public void LogWarning(string message)
+        {
+            Console.WriteLine($"Redpoint.Uet.Patching.Runtime [warn] {message}");
+        }
+
+        public void LogError(string message)
+        {
+            Console.WriteLine($"Redpoint.Uet.Patching.Runtime [fail] {message}");
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Patching.Runtime/IUetPatchLogging.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/IUetPatchLogging.cs
@@ -1,0 +1,11 @@
+﻿namespace Redpoint.Uet.Patching.Runtime
+{
+    internal interface IUetPatchLogging
+    {
+        void LogInfo(string message);
+
+        void LogWarning(string message);
+
+        void LogError(string message);
+    }
+}

--- a/UET/Redpoint.Uet.Patching.Runtime/NullUetPatchLogging.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/NullUetPatchLogging.cs
@@ -1,0 +1,17 @@
+﻿namespace Redpoint.Uet.Patching.Runtime
+{
+    internal class NullUetPatchLogging : IUetPatchLogging
+    {
+        public void LogInfo(string message)
+        {
+        }
+
+        public void LogWarning(string message)
+        {
+        }
+
+        public void LogError(string message)
+        {
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Patching.Runtime/Patches/IUetPatch.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/Patches/IUetPatch.cs
@@ -1,0 +1,12 @@
+﻿namespace Redpoint.Uet.Patching.Runtime.Patches
+{
+    using HarmonyLib;
+    using Redpoint.Uet.Patching.Runtime;
+
+    internal interface IUetPatch
+    {
+        bool ShouldApplyPatch();
+
+        void ApplyPatch(IUetPatchLogging logging, Harmony harmony);
+    }
+}

--- a/UET/Redpoint.Uet.Patching.Runtime/Patches/TestUetPatch.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/Patches/TestUetPatch.cs
@@ -1,0 +1,18 @@
+﻿namespace Redpoint.Uet.Patching.Runtime.Patches
+{
+    using HarmonyLib;
+    using System.Reflection;
+
+    internal class TestUetPatch : IUetPatch
+    {
+        public bool ShouldApplyPatch()
+        {
+            return Assembly.GetEntryAssembly()?.GetName()?.Name == "AutomationTool";
+        }
+
+        public void ApplyPatch(IUetPatchLogging logging, Harmony harmony)
+        {
+            logging.LogInfo("Test patch is running for AutomationTool.");
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Patching.Runtime/Redpoint.Uet.Patching.Runtime.csproj
+++ b/UET/Redpoint.Uet.Patching.Runtime/Redpoint.Uet.Patching.Runtime.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Lib.Harmony" />
+	</ItemGroup>
+
+</Project>

--- a/UET/Redpoint.Uet.Patching.Runtime/StartupHook.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/StartupHook.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+internal class StartupHook
+{
+    public static void Initialize()
+    {
+        // Set our assembly resolver for Mono.Cecil and other things.
+        var ourDirectoryPath = new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName!;
+        AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext context, AssemblyName name) =>
+        {
+            var targetAssembly = Path.Combine(ourDirectoryPath, name.Name + ".dll");
+            if (File.Exists(targetAssembly))
+            {
+                return Assembly.LoadFrom(targetAssembly);
+            }
+            return null;
+        };
+
+        // Then call our real code.
+        Redpoint.Uet.Patching.Runtime.UetStartupHook.Initialize();
+    }
+}

--- a/UET/Redpoint.Uet.Patching.Runtime/UetStartupHook.cs
+++ b/UET/Redpoint.Uet.Patching.Runtime/UetStartupHook.cs
@@ -1,0 +1,44 @@
+﻿namespace Redpoint.Uet.Patching.Runtime
+{
+    using HarmonyLib;
+    using Redpoint.Uet.Patching.Runtime.Patches;
+    using System;
+
+    public static class UetStartupHook
+    {
+        public static void Initialize()
+        {
+            // Prevent MSBuild from re-using nodes, since we're injected into all .NET processes (including MSBuild).
+            Environment.SetEnvironmentVariable("MSBUILDDISABLENODEREUSE", "1");
+
+            // Our list of patches.
+            var patches = new IUetPatch[]
+            {
+                new TestUetPatch(),
+            };
+
+            // Determine if we have any patches to apply. If we have none, we're done.
+            if (!patches.Any(x => x.ShouldApplyPatch()))
+            {
+                return;
+            }
+
+            // Create our logging instance.
+            IUetPatchLogging logging = Environment.GetEnvironmentVariable("UET_RUNTIME_PATCHING_ENABLE_LOGGING") == "1"
+                ? new ConsoleUetPatchLogging()
+                : new NullUetPatchLogging();
+
+            // Create our Harmony instance.
+            var harmony = new Harmony("games.redpoint.uet");
+
+            // Go through our patches and apply the ones that are relevant.
+            foreach (var patch in patches)
+            {
+                if (patch.ShouldApplyPatch())
+                {
+                    patch.ApplyPatch(logging, harmony);
+                }
+            }
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Uat.Tests/UATExecutionTests.cs
+++ b/UET/Redpoint.Uet.Uat.Tests/UATExecutionTests.cs
@@ -18,10 +18,10 @@ namespace Redpoint.Uet.Uat.Tests
             services.AddPathResolution();
             services.AddProcessExecution();
             services.AddUetCore();
-            services.AddUETUAT();
+            services.AddUetUat();
 
             var serviceProvider = services.BuildServiceProvider();
-            var executor = serviceProvider.GetRequiredService<IUATExecutor>();
+            var executor = serviceProvider.GetRequiredService<IUatExecutor>();
 
             var lines = new List<string>();
             var exitCode = await executor.ExecuteAsync(

--- a/UET/Redpoint.Uet.Uat/DefaultUATExecutor.cs
+++ b/UET/Redpoint.Uet.Uat/DefaultUATExecutor.cs
@@ -9,13 +9,14 @@
     using System.Text.Json;
     using System.Text.Json.Serialization;
 
-    internal class DefaultUATExecutor : IUATExecutor
+    internal class DefaultUatExecutor : IUatExecutor
     {
         private readonly IProcessExecutor _processExecutor;
-        private readonly ILogger<DefaultUATExecutor> _logger;
+        private readonly ILogger<DefaultUatExecutor> _logger;
         private readonly ILocalHandleCloser _localHandleCloser;
         private readonly IRemoteHandleCloser _remoteHandleCloser;
         private readonly IWorldPermissionApplier _worldPermissionApplier;
+        private readonly IUatStartupHookProvider _uatStartupHookProvider;
 
         internal class ScriptModuleJson
         {
@@ -26,18 +27,20 @@
             public string? TargetPath { get; set; }
         }
 
-        public DefaultUATExecutor(
+        public DefaultUatExecutor(
             IProcessExecutor processExecutor,
-            ILogger<DefaultUATExecutor> logger,
+            ILogger<DefaultUatExecutor> logger,
             ILocalHandleCloser localHandleCloser,
             IRemoteHandleCloser remoteHandleCloser,
-            IWorldPermissionApplier worldPermissionApplier)
+            IWorldPermissionApplier worldPermissionApplier,
+            IUatStartupHookProvider uatStartupHookProvider)
         {
             _processExecutor = processExecutor;
             _logger = logger;
             _localHandleCloser = localHandleCloser;
             _remoteHandleCloser = remoteHandleCloser;
             _worldPermissionApplier = worldPermissionApplier;
+            _uatStartupHookProvider = uatStartupHookProvider;
         }
 
         public async Task<int> ExecuteAsync(
@@ -159,6 +162,9 @@
                 }
             }
 
+            // Extract the hooks and set DOTNET_STARTUP_HOOKS.
+            var dotnetStartupHooks = await _uatStartupHookProvider.GetDotnetStartupHooksPathAsync();
+
             // Generate the final environment variable values.
             var uatEnvironmentVariables = new Dictionary<string, string>();
             if (uatSpecification.EnvironmentVariables != null)
@@ -171,6 +177,7 @@
             uatEnvironmentVariables["UnrealBuildTool_ParallelExecutor__ProcessorCountMultiplier"] = OperatingSystem.IsMacOS() ? "1" : "2";
             uatEnvironmentVariables["UnrealBuildTool_ParallelExecutor__MemoryPerActionBytes"] = "0";
             uatEnvironmentVariables["UnrealBuildTool_ParallelExecutor__bShowCompilationTimes"] = "true";
+            uatEnvironmentVariables["DOTNET_STARTUP_HOOKS"] = dotnetStartupHooks;
 
             // Execute UAT, automatically handling retries as needed.
             int reportedExitCode = -1;

--- a/UET/Redpoint.Uet.Uat/DefaultUatStartupHookProvider.cs
+++ b/UET/Redpoint.Uet.Uat/DefaultUatStartupHookProvider.cs
@@ -1,0 +1,115 @@
+﻿namespace Redpoint.Uet.Uat
+{
+    using Redpoint.Hashing;
+    using Redpoint.Reservation;
+    using Redpoint.Uet.Workspace.Reservation;
+    using System;
+    using System.Reflection;
+    using System.Text;
+
+    internal class DefaultUatStartupHookProvider : IUatStartupHookProvider, IAsyncDisposable
+    {
+        private readonly IReservationManagerForUet _reservationManagerForUet;
+        private SemaphoreSlim _resolvingSemaphore = new SemaphoreSlim(1);
+        private string? _resolvedPath;
+        private IReservation? _resolvedWorkspace;
+
+        public DefaultUatStartupHookProvider(
+            IReservationManagerForUet reservationManagerForUet)
+        {
+            _reservationManagerForUet = reservationManagerForUet;
+        }
+
+        public async Task<string> GetDotnetStartupHooksPathAsync()
+        {
+            if (_resolvedPath != null)
+            {
+                return _resolvedPath;
+            }
+
+            await _resolvingSemaphore.WaitAsync();
+            try
+            {
+                if (_resolvedPath != null)
+                {
+                    return _resolvedPath;
+                }
+
+                var manifestResourcePrefix = "Redpoint.Uet.Uat.Embedded.";
+
+                // First, hash the embedded contents that we have. This allows us to only instantiate a new copy when we have different binaries compared with a different version of UET.
+                XxHash64WithLength hash;
+                {
+                    using var streamForHashing = new MemoryStream();
+                    foreach (var manifestResourceStreamName in Assembly.GetExecutingAssembly().GetManifestResourceNames())
+                    {
+                        if (manifestResourceStreamName.StartsWith(manifestResourcePrefix, StringComparison.Ordinal))
+                        {
+                            var filename = manifestResourceStreamName.Substring(manifestResourcePrefix.Length);
+                            await streamForHashing.WriteAsync(Encoding.UTF8.GetBytes(filename));
+
+                            using var manifestResourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(manifestResourceStreamName);
+                            if (manifestResourceStream != null)
+                            {
+                                await manifestResourceStream.CopyToAsync(streamForHashing);
+                            }
+                        }
+                    }
+                    hash = await Hash.XxHash64Async(streamForHashing);
+                }
+
+                var workspace = await _reservationManagerForUet.ReserveAsync("UetRuntimePatches", new string[] { hash.ToString() });
+                try
+                {
+                    // Extract only if the workspace isn't already set up.
+                    if (!File.Exists(Path.Combine(workspace.ReservedPath, "extracted")))
+                    {
+                        foreach (var manifestResourceStreamName in Assembly.GetExecutingAssembly().GetManifestResourceNames())
+                        {
+                            if (manifestResourceStreamName.StartsWith(manifestResourcePrefix, StringComparison.Ordinal))
+                            {
+                                var filename = manifestResourceStreamName.Substring(manifestResourcePrefix.Length);
+                                using (var fileStream = new FileStream(Path.Combine(workspace.ReservedPath, filename), FileMode.Create, FileAccess.Write, FileShare.None))
+                                {
+                                    using var manifestResourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(manifestResourceStreamName);
+                                    await manifestResourceStream!.CopyToAsync(fileStream);
+                                }
+                            }
+                        }
+
+                        File.WriteAllText(
+                            Path.Combine(workspace.ReservedPath, "extracted"),
+                            "ok");
+                    }
+
+                    _resolvedPath = Path.Combine(workspace.ReservedPath, "Redpoint.Uet.Patching.Runtime.dll");
+                    _resolvedWorkspace = workspace;
+                }
+                finally
+                {
+                    if (_resolvedPath == null)
+                    {
+                        await workspace.DisposeAsync();
+                    }
+                }
+            }
+            finally
+            {
+                _resolvingSemaphore.Release();
+            }
+
+            return _resolvedPath;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_resolvedWorkspace != null)
+            {
+                await _resolvedWorkspace.DisposeAsync();
+                _resolvedWorkspace = null;
+            }
+
+            _resolvingSemaphore.Dispose();
+        }
+    }
+}

--- a/UET/Redpoint.Uet.Uat/IUATExecutor.cs
+++ b/UET/Redpoint.Uet.Uat/IUATExecutor.cs
@@ -2,7 +2,7 @@
 {
     using Redpoint.ProcessExecution;
 
-    public interface IUATExecutor
+    public interface IUatExecutor
     {
         Task<int> ExecuteAsync(
             string enginePath,

--- a/UET/Redpoint.Uet.Uat/IUatStartupHookProvider.cs
+++ b/UET/Redpoint.Uet.Uat/IUatStartupHookProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace Redpoint.Uet.Uat
+{
+    using System.Collections.Generic;
+
+    internal interface IUatStartupHookProvider
+    {
+        Task<string> GetDotnetStartupHooksPathAsync();
+    }
+}

--- a/UET/Redpoint.Uet.Uat/Redpoint.Uet.Uat.csproj
+++ b/UET/Redpoint.Uet.Uat/Redpoint.Uet.Uat.csproj
@@ -1,17 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$(MSBuildThisFileDirectory)../Lib/Common.Build.props" />
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/Common.Build.props" />
 
-  <Import Project="$(MSBuildThisFileDirectory)../Lib/CsWin32.Build.props" />
+	<Import Project="$(MSBuildThisFileDirectory)../Lib/CsWin32.Build.props" />
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Redpoint.ProcessExecution\Redpoint.ProcessExecution.csproj" />
-    <ProjectReference Include="..\Redpoint.Uet.Core\Redpoint.Uet.Core.csproj" />
-    <ProjectReference Include="..\Redpoint.Windows.HandleManagement\Redpoint.Windows.HandleManagement.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Redpoint.ProcessExecution\Redpoint.ProcessExecution.csproj" />
+		<ProjectReference Include="..\Redpoint.Uet.Core\Redpoint.Uet.Core.csproj" />
+		<ProjectReference Include="..\Redpoint.Uet.Workspace\Redpoint.Uet.Workspace.csproj" />
+		<ProjectReference Include="..\Redpoint.Windows.HandleManagement\Redpoint.Windows.HandleManagement.csproj" />
+		<ProjectReference Include="..\Redpoint.Uet.Patching.Runtime\Redpoint.Uet.Patching.Runtime.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="..\Redpoint.Uet.Patching.Runtime\bin\$(Configuration)\net6.0\*.dll">
+			<Link>Embedded\%(Filename)%(Extension)</Link>
+		</EmbeddedResource>
+	</ItemGroup>
 
 </Project>

--- a/UET/Redpoint.Uet.Uat/ScriptModuleJsonSourceGenerationContext.cs
+++ b/UET/Redpoint.Uet.Uat/ScriptModuleJsonSourceGenerationContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace Redpoint.Uet.Uat
 {
     using System.Text.Json.Serialization;
-    using static Redpoint.Uet.Uat.DefaultUATExecutor;
+    using static Redpoint.Uet.Uat.DefaultUatExecutor;
 
     [JsonSourceGenerationOptions(WriteIndented = true)]
     [JsonSerializable(typeof(ScriptModuleJson))]

--- a/UET/Redpoint.Uet.Uat/UETUATServiceExtensions.cs
+++ b/UET/Redpoint.Uet.Uat/UETUATServiceExtensions.cs
@@ -7,9 +7,9 @@ namespace Redpoint.Uet.Uat
     using Microsoft.Extensions.DependencyInjection;
     using Redpoint.Uet.Uat.Internal;
 
-    public static class UETUATServiceExtensions
+    public static class UetUatServiceExtensions
     {
-        public static void AddUETUAT(this IServiceCollection services)
+        public static void AddUetUat(this IServiceCollection services)
         {
             if (OperatingSystem.IsWindowsVersionAtLeast(6, 2))
             {
@@ -21,7 +21,8 @@ namespace Redpoint.Uet.Uat
             }
             services.AddSingleton<IRemoteHandleCloser, DefaultRemoteHandleCloser>();
 
-            services.AddSingleton<IUATExecutor, DefaultUATExecutor>();
+            services.AddSingleton<IUatExecutor, DefaultUatExecutor>();
+            services.AddSingleton<IUatStartupHookProvider, DefaultUatStartupHookProvider>();
         }
     }
 }

--- a/UET/UET.sln
+++ b/UET/UET.sln
@@ -414,6 +414,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.CloudFramework.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.CloudFramework.TestService", "Redpoint.CloudFramework.TestService\Redpoint.CloudFramework.TestService.csproj", "{9A2F8287-70AC-4085-91EB-8865D482C54E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Redpoint.Uet.Patching.Runtime", "Redpoint.Uet.Patching.Runtime\Redpoint.Uet.Patching.Runtime.csproj", "{C88BE677-5DCE-4933-95A4-F0CFABE25FC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1132,6 +1134,10 @@ Global
 		{9A2F8287-70AC-4085-91EB-8865D482C54E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A2F8287-70AC-4085-91EB-8865D482C54E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A2F8287-70AC-4085-91EB-8865D482C54E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C88BE677-5DCE-4933-95A4-F0CFABE25FC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C88BE677-5DCE-4933-95A4-F0CFABE25FC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C88BE677-5DCE-4933-95A4-F0CFABE25FC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C88BE677-5DCE-4933-95A4-F0CFABE25FC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1280,6 +1286,7 @@ Global
 		{63273CA6-C996-E77C-BFBB-411A10FF1785} = {A1E49E48-240A-4799-A9F3-988CC1E9D0CE}
 		{C5185D7B-8085-43C9-BB1C-A72BF6567393} = {A93D92E5-865B-4681-AC53-4B1689F1B3E8}
 		{9A2F8287-70AC-4085-91EB-8865D482C54E} = {A93D92E5-865B-4681-AC53-4B1689F1B3E8}
+		{C88BE677-5DCE-4933-95A4-F0CFABE25FC5} = {1AE4AFCD-0F49-4CEA-8439-F1AAA2CDD183}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8598A278-509A-48A6-A7B3-3E3B0D1011F1}

--- a/UET/uet/Commands/UetCommandExecution.cs
+++ b/UET/uet/Commands/UetCommandExecution.cs
@@ -99,7 +99,7 @@
             services.AddPackageManagement();
             services.AddUet();
             services.AddUETAutomation();
-            services.AddUETUAT();
+            services.AddUetUat();
             services.AddUETBuildPipeline();
             services.AddUETBuildPipelineExecutorsLocal();
             services.AddUETBuildPipelineExecutorsGitLab();


### PR DESCRIPTION
This doesn't actually apply any useful patches yet, but it's the interesting infrastructure code from #35 (which is otherwise no longer applicable).